### PR TITLE
Add tags and improve cli task filters

### DIFF
--- a/sayn/commands/sayn_powers.py
+++ b/sayn/commands/sayn_powers.py
@@ -15,8 +15,18 @@ click_debug = click.option(
 
 
 def click_filter(func):
-    func = click.option("--include", "-i", multiple=True, help="Include query",)(func)
-    func = click.option("--exclude", "-x", multiple=True, help="Exclude query",)(func)
+    func = click.option(
+        "--tasks",
+        "-t",
+        multiple=True,
+        help="Task query to INCLUDE in the execution: [+]task_name[+], model:model_name, tag:tag_name",
+    )(func)
+    func = click.option(
+        "--exclude",
+        "-x",
+        multiple=True,
+        help="Task query to EXCLUDE in the execution: [+]task_name[+], model:model_name, tag:tag_name",
+    )(func)
     return func
 
 
@@ -65,19 +75,19 @@ def init(sayn_project_name):
 
 @cli.command(help="Compile sql tasks.")
 @click_run_options
-def compile(debug, include, exclude, profile, full_load, start_dt, end_dt):
+def compile(debug, tasks, exclude, profile, full_load, start_dt, end_dt):
     run_command(
-        "compile", debug, include, exclude, profile, full_load, start_dt, end_dt
+        "compile", debug, tasks, exclude, profile, full_load, start_dt, end_dt
     )
 
 
 @cli.command(help="Run SAYN tasks.")
 @click_run_options
-def run(debug, include, exclude, profile, full_load, start_dt, end_dt):
-    run_command("run", debug, include, exclude, profile, full_load, start_dt, end_dt)
+def run(debug, tasks, exclude, profile, full_load, start_dt, end_dt):
+    run_command("run", debug, tasks, exclude, profile, full_load, start_dt, end_dt)
 
 
-def run_command(command, debug, include, exclude, profile, full_load, start_dt, end_dt):
+def run_command(command, debug, tasks, exclude, profile, full_load, start_dt, end_dt):
     run_start_ts = datetime.now()
     run_id = (run_start_ts - datetime(1970, 1, 1)).total_seconds()
 
@@ -91,7 +101,7 @@ def run_command(command, debug, include, exclude, profile, full_load, start_dt, 
         logging.error(e)
         sys.exit(1)
 
-    dag = Dag(include=include, exclude=exclude)
+    dag = Dag(tasks_query=tasks, exclude_query=exclude)
 
     if command == "run":
         dag.run()
@@ -106,7 +116,7 @@ def run_command(command, debug, include, exclude, profile, full_load, start_dt, 
 @cli.command(help="Generate DAG image")
 @click_debug
 @click_filter
-def dag_image(debug, include, exclude):
+def dag_image(debug, tasks, exclude):
     run_start_ts = datetime.now()
     run_id = (run_start_ts - datetime(1970, 1, 1)).total_seconds()
 
@@ -118,5 +128,5 @@ def dag_image(debug, include, exclude):
         logging.error(e)
         sys.exit(1)
 
-    dag = Dag(include=include, exclude=exclude)
+    dag = Dag(tasks_query=tasks, exclude_query=exclude)
     dag.plot(folder="images", file_name="dag")

--- a/sayn/commands/sayn_powers.py
+++ b/sayn/commands/sayn_powers.py
@@ -15,8 +15,8 @@ click_debug = click.option(
 
 
 def click_filter(func):
-    func = click.option("--include", "-i", multiple=False, help="Include query",)(func)
-    func = click.option("--exclude", "-x", multiple=False, help="Exclude query",)(func)
+    func = click.option("--include", "-i", multiple=True, help="Include query",)(func)
+    func = click.option("--exclude", "-x", multiple=True, help="Exclude query",)(func)
     return func
 
 

--- a/sayn/dag.py
+++ b/sayn/dag.py
@@ -72,7 +72,11 @@ class Dag:
             m: [i[1] for i in g]
             for m, g in groupby(
                 sorted(
-                    [(t["model"], n) for n, t in task_definitions.items()],
+                    [
+                        (t["model"], n)
+                        for n, t in task_definitions.items()
+                        if t["model"] is not None
+                    ],
                     key=lambda x: x[0],
                 ),
                 lambda x: x[0],

--- a/sayn/dag.py
+++ b/sayn/dag.py
@@ -22,7 +22,7 @@ class Dag:
     graph = OrderedDict()
     tasks = dict()
 
-    def __init__(self, include=(), exclude=()):
+    def __init__(self, tasks_query=(), exclude_query=()):
         Logger().set_config(stage="DAG")
         logging.info("----------")
         logging.info(f"Setting up. Run ID: {Config().run_id}")
@@ -75,14 +75,14 @@ class Dag:
             )
         }
 
-        if len(include) == 0:
+        if len(tasks_query) == 0:
             tasks_to_process = set(self.tasks.keys())
         else:
             tasks_to_process = set(
-                t for q in include for t in self._task_query(tags, models, q)
+                t for q in tasks_query for t in self._task_query(tags, models, q)
             )
         tasks_to_process = tasks_to_process - set(
-            t for q in exclude for t in self._task_query(tags, models, q)
+            t for q in exclude_query for t in self._task_query(tags, models, q)
         )
 
         # Create task objects and set them up
@@ -141,7 +141,7 @@ class Dag:
             return models[model]
 
         elif query in self.tasks:
-            return [task]
+            return [query]
 
         else:
             raise KeyError(f'Task "{query}" not in dag')

--- a/sayn/dag.py
+++ b/sayn/dag.py
@@ -79,14 +79,17 @@ class Dag:
         tags = {
             m: [i[1] for i in g]
             for m, g in groupby(
-                [
-                    (tag, n)
-                    for n, t in task_definitions.items()
-                    for tag in set(
-                        [tt for tt in t["group"].data.get("tags", list())]
-                        + [tt for tt in t["task"].data.get("tags", list())]
-                    )
-                ],
+                sorted(
+                    [
+                        (tag, n)
+                        for n, t in task_definitions.items()
+                        for tag in set(
+                            [tt for tt in t["group"].data.get("tags", list())]
+                            + [tt for tt in t["task"].data.get("tags", list())]
+                        )
+                    ],
+                    key=lambda x: x[0],
+                ),
                 lambda x: x[0],
             )
         }
@@ -94,7 +97,11 @@ class Dag:
         models = {
             m: [i[1] for i in g]
             for m, g in groupby(
-                [(t["model"], n) for n, t in task_definitions.items()], lambda x: x[0]
+                sorted(
+                    [(t["model"], n) for n, t in task_definitions.items()],
+                    key=lambda x: x[0],
+                ),
+                lambda x: x[0],
             )
         }
 
@@ -142,7 +149,6 @@ class Dag:
                 task_name for task_name in task_list if task_name not in tags[tag]
             ]
         elif exclude is not None and exclude[:6] == "model:":
-            model = exclude[4:]
             if model not in models:
                 raise KeyError(f'Tag "{model}" not in dag')
 

--- a/sayn/tasks/task.py
+++ b/sayn/tasks/task.py
@@ -53,6 +53,7 @@ class Task(object):
 
         self.type = _task_def.pop("type")
         self.group = _task_def.pop("group", None)
+        self.tags = _task_def.pop("group", list())
         self.parents = _task_def.pop("parents", list())
 
         self.parameters = _task_def.pop("parameters", dict())

--- a/sayn/tasks/task.py
+++ b/sayn/tasks/task.py
@@ -53,7 +53,7 @@ class Task(object):
 
         self.type = _task_def.pop("type")
         self.group = _task_def.pop("group", None)
-        self.tags = _task_def.pop("group", list())
+        self.tags = _task_def.pop("tags", list())
         self.parents = _task_def.pop("parents", list())
 
         self.parameters = _task_def.pop("parameters", dict())


### PR DESCRIPTION
### This PR:
- Adds the concept of `tags` that can be applied to tasks
- Reworks the `tasks` filter from the cli to accept multiple entries
- Allows referencing tags and models as well as tasks in the task query in the cli
- Adds and `exclude` option to the cli

### TODO
- [x] Add tag property to tasks and groups
- [x] Replace `--model` and `--task` command options with `--include` supporting `model:`, `tag:` and `(+)task(+)` values
- [x] Add `--exclude` flag with `model:` and `tag:` specs
- [x] Add multiple entries in `--include` and `--exclude`
- [x] Change `--include` for `--task`
- [x] Add `(+)task(+)` to `--exclude`

### Testing
Example:
```
tasks:
  test1:
    type: dummy
    tags:
      - marketing
      - skip_default_run

  test2:
    type: dummy
    tags:
      - marketing
```
Now we can do:
- `sayn run -t tag:marketing` which will run all tasks with the `marketing` tag (test1 and test2)
- `sayn run -x tag:skip_default_run` which will run all tasks that don't have the `skip_default_run` (test2)
- `sayn run -t test1 -t test2` which will run the tasks specified (test1 and test2)
- We can also add the the `tags` to the group definition and so the tags list from the group will be combined with the tag list in the task