### PR TITLE
Review main concepts in SAYN

### DIFF
--- a/sayn/__init__.py
+++ b/sayn/__init__.py
@@ -2,7 +2,7 @@ __doc__ = """
 # SAYN
 """
 
+from .config import Config, SaynConfigError
+from .dag import Dag, DagValidationError
 from .tasks import PythonTask
-from .dag import Dag
-from .config import Config
 from .utils.logger import Logger

--- a/sayn/commands/sayn_powers.py
+++ b/sayn/commands/sayn_powers.py
@@ -19,13 +19,13 @@ def click_filter(func):
         "--tasks",
         "-t",
         multiple=True,
-        help="Task query to INCLUDE in the execution: [+]task_name[+], model:model_name, tag:tag_name",
+        help="Task query to INCLUDE in the execution: [+]task_name[+], dag:dag_name, tag:tag_name",
     )(func)
     func = click.option(
         "--exclude",
         "-x",
         multiple=True,
-        help="Task query to EXCLUDE in the execution: [+]task_name[+], model:model_name, tag:tag_name",
+        help="Task query to EXCLUDE in the execution: [+]task_name[+], dag:dag_name, tag:tag_name",
     )(func)
     return func
 

--- a/sayn/config.py
+++ b/sayn/config.py
@@ -258,11 +258,11 @@ class Config:
                 logging.error(f'Environment variable "{key}" is not recognised')
                 return
 
-            # Ensure all credentials are specified
-            for credential in required_credentials:
-                if credential not in credentials:
-                    logging.error(f'Missing credential "{credential}"')
-                    return
+        # Ensure all credentials are specified
+        for credential in required_credentials:
+            if credential not in credentials:
+                logging.error(f'Missing credential "{credential}"')
+                return
 
         return {
             "selected_profile": None,

--- a/sayn/config.py
+++ b/sayn/config.py
@@ -401,9 +401,9 @@ class Config:
             raise SaynConfigError(f"Missing file: {path.fullname}")
 
         loader = importlib.machinery.SourceFileLoader(
-            "python_tasks", str(Path(self.python_path, "__init__.py"))
+            "sayn_python_tasks", str(Path(self.python_path, "__init__.py"))
         )
-        spec = importlib.util.spec_from_loader("python_tasks", loader)
+        spec = importlib.util.spec_from_loader("sayn_python_tasks", loader)
         m = None
         m = importlib.util.module_from_spec(spec)
 

--- a/sayn/config.py
+++ b/sayn/config.py
@@ -116,7 +116,7 @@ class Config:
                 "required_credentials": yaml.UniqueSeq(yaml.NotEmptyStr()),
                 yaml.Optional("default_db"): yaml.NotEmptyStr(),
                 yaml.Optional("presets"): yaml.MapPattern(
-                    yaml.NotEmptyStr(), yaml.MapPattern(yaml.NotEmptyStr(), yaml.Any()),
+                    yaml.Identifier(), yaml.MapPattern(yaml.NotEmptyStr(), yaml.Any()),
                 ),
                 yaml.Optional("groups"): yaml.UniqueSeq(yaml.Enum(groups.keys())),
             }
@@ -170,10 +170,10 @@ class Config:
         schema = yaml.Map(
             {
                 yaml.Optional("presets"): yaml.MapPattern(
-                    yaml.NotEmptyStr(), yaml.MapPattern(yaml.NotEmptyStr(), yaml.Any()),
+                    yaml.Identifier(), yaml.MapPattern(yaml.NotEmptyStr(), yaml.Any()),
                 ),
                 "tasks": yaml.MapPattern(
-                    yaml.NotEmptyStr(), yaml.MapPattern(yaml.NotEmptyStr(), yaml.Any()),
+                    yaml.Identifier(), yaml.MapPattern(yaml.NotEmptyStr(), yaml.Any()),
                 ),
             }
         )

--- a/sayn/config.py
+++ b/sayn/config.py
@@ -78,26 +78,26 @@ class Config:
     ###############################
 
     def _read_config(self, profile):
-        models = self._read_project()
-        if models is None:
+        project = self._read_project()
+        if project is None:
             return
 
         settings = self._read_settings(
-            profile, models["required_credentials"], list(models["parameters"].keys()),
+            profile, project["required_credentials"], list(project["parameters"].keys()),
         )
         if settings is None:
             return
 
-        parameters = models["parameters"]
+        parameters = project["parameters"]
         parameters.update(settings["parameters"])
 
         return {
             "selected_profile": settings["selected_profile"],
             "parameters": parameters,
-            "default_db": models["default_db"],
+            "default_db": project["default_db"],
             "credentials": settings["credentials"],
-            "presets": models["presets"],
-            "groups": models["groups"],
+            "presets": project["presets"],
+            "groups": project["groups"],
         }
 
     def _read_project(self):

--- a/sayn/dag.py
+++ b/sayn/dag.py
@@ -263,7 +263,7 @@ class Dag:
     def compile(self):
         self._run_command("compile")
 
-    def plot_dag(self, folder=None, file_name=None):
+    def plot(self, folder=None, file_name=None):
         """Uses graphviz to plot the dag
         It requires the graphviz python package (pip install graphviz) and an installation of graphviz
         (eg: brew install graphviz)

--- a/sayn/dag.py
+++ b/sayn/dag.py
@@ -137,9 +137,9 @@ class Dag:
                 raise KeyError(f'Tag "{tag}" not in dag')
             return tags[tag]
 
-        elif query[:6] == "dag:":
+        elif query[:4] == "dag:":
             # A dag name will be specified as `dag:dag_name`
-            dag = query[6:]
+            dag = query[4:]
             if dag not in dags:
                 raise KeyError(f'DAG "{dag}" does not exists')
             return dags[dag]

--- a/sayn/dag.py
+++ b/sayn/dag.py
@@ -56,7 +56,7 @@ class Dag:
             )
         }
 
-        # 2. Get a dict of models > list of tasks with that model (used by _task_query to get the list of relevant tasks)
+        # 2. Get a dict of groups > task list with that model (used by _task_query to get the list of relevant tasks)
         groups = {
             group: [i[1] for i in group_tasks]
             for group, group_tasks in groupby(
@@ -138,7 +138,7 @@ class Dag:
             return tags[tag]
 
         elif query[:6] == "group:":
-            # A group name will be specified as `group:model_name`
+            # A group name will be specified as `group:group_name`
             group = query[6:]
             if group not in groups:
                 raise KeyError(f'Group "{group}" not in dag')

--- a/sayn/dag.py
+++ b/sayn/dag.py
@@ -32,15 +32,7 @@ class Dag:
 
         # Setup DAG structure using just names and parents
         self._from_dict_reversed(
-            {
-                k: list(
-                    set(
-                        v["task"].data.get("parents", list())
-                        + v["group"].data.get("parents", list())
-                    )
-                )
-                for k, v in task_definitions.items()
-            }
+            {k: v.get("parents", list()) for k, v in task_definitions.items()}
         )
 
         # Calculate list of tasks in the correct order of execution based on parentage
@@ -50,16 +42,13 @@ class Dag:
 
         # 1. Get a dict of tags > list of tasks with that tag (used by _task_query to get the list of relevant tasks)
         tags = {
-            m: [i[1] for i in g]
-            for m, g in groupby(
+            tag: [i[1] for i in tag_tasks]
+            for tag, tag_tasks in groupby(
                 sorted(
                     [
-                        (tag, n)
-                        for n, t in task_definitions.items()
-                        for tag in set(
-                            [tt for tt in t["group"].data.get("tags", list())]
-                            + [tt for tt in t["task"].data.get("tags", list())]
-                        )
+                        (tag, task_name)
+                        for task_name, task_def in task_definitions.items()
+                        for tag in task_def.get("tags", list())
                     ],
                     key=lambda x: x[0],
                 ),
@@ -68,14 +57,13 @@ class Dag:
         }
 
         # 2. Get a dict of models > list of tasks with that model (used by _task_query to get the list of relevant tasks)
-        models = {
-            m: [i[1] for i in g]
-            for m, g in groupby(
+        groups = {
+            group: [i[1] for i in group_tasks]
+            for group, group_tasks in groupby(
                 sorted(
                     [
-                        (t["model"], n)
-                        for n, t in task_definitions.items()
-                        if t["model"] is not None
+                        (task_def["group"], task_name)
+                        for task_name, task_def in task_definitions.items()
                     ],
                     key=lambda x: x[0],
                 ),
@@ -90,30 +78,30 @@ class Dag:
         else:
             # Otherwise we get the list of tasks corresponding to what's specified in --tasks
             tasks_to_process = set(
-                t for q in tasks_query for t in self._task_query(tags, models, q)
+                t for q in tasks_query for t in self._task_query(tags, groups, q)
             )
 
         # We always apply the exclude filter query
         tasks_to_process = tasks_to_process - set(
-            t for q in exclude_query for t in self._task_query(tags, models, q)
+            t for q in exclude_query for t in self._task_query(tags, groups, q)
         )
 
         # Create task objects and set them up
         self.tasks = {
             name: create_task(
                 name,
-                task_definitions[name]["type"].data,
-                task_definitions[name]["task"],
-                task_definitions[name]["group"],
-                task_definitions[name]["model"],
+                task_definitions[name]["type"],
+                task_definitions[name],
                 name not in tasks_to_process,
             )
             for name in self.tasks.keys()
         }
 
+        # Once all objects are created, we can add references to those in each task
         for _, task in self.tasks.items():
             task.set_parents(self.tasks)
 
+        # Run the setup for each task
         for _, task in self.tasks.items():
             Logger().set_config(task=task.name)
             if task.status == TaskStatus.FAILED:
@@ -121,13 +109,11 @@ class Dag:
             task.setup()
 
         # delete the task_definitions attribute from the config so it we do not have tasks on both APIs
-        delattr(Config(), "_task_definitions")
+        # delattr(Config(), "_task_definitions")
         Logger().set_config(task=None)
         logging.info("DAG Setup: done.")
 
-    # API
-
-    def _task_query(self, tags, models, query):
+    def _task_query(self, tags, groups, query):
         """Returns a list of tasks from the dag matching the query"""
 
         if query[0] == "+":
@@ -151,12 +137,12 @@ class Dag:
                 raise KeyError(f'Tag "{tag}" not in dag')
             return tags[tag]
 
-        elif query[:6] == "model:":
-            # A model name will be specified as `model:model_name`
-            model = query[6:]
-            if model not in models:
-                raise KeyError(f'Model "{model}" not in dag')
-            return models[model]
+        elif query[:6] == "group:":
+            # A group name will be specified as `group:model_name`
+            group = query[6:]
+            if group not in groups:
+                raise KeyError(f'Group "{group}" not in dag')
+            return groups[group]
 
         elif query in self.tasks:
             # Otherwise it should be a single task name
@@ -165,6 +151,43 @@ class Dag:
         else:
             # ... or the task doesn't exists in the dag
             raise KeyError(f'Task "{query}" not in dag')
+
+    def _run_task(self, command, task):
+        Logger().set_config(task=task.name)
+        task_start_ts = datetime.now()
+        if task.status != TaskStatus.READY:
+            task.failed("Task failed during setup. Skipping...")
+        elif not task.can_run():
+            logging.warn("SKIPPING")
+            task.skipped()
+        else:
+            logging.debug("Starting")
+            task.executing()
+            try:
+                if command == "compile":
+                    status = task.compile()
+                elif command == "run":
+                    status = task.run()
+                else:
+                    status = None
+            except Exception as e:
+                logging.exception(e)
+
+                status = None
+
+            if status is None:
+                task.status = TaskStatus.UNKNOWN
+                logging.error(
+                    f"Finished in an unknown state ({datetime.now() - task_start_ts})"
+                )
+            elif status != TaskStatus.SUCCESS:
+                logging.error(f"Failed status ({datetime.now() - task_start_ts})")
+            else:
+                logging.info(
+                    f"\u001b[32mSuccess ({datetime.now() - task_start_ts})\u001b[0m"
+                )
+
+        return task.status
 
     def _run_command(self, command):
         Logger().set_config(stage="Run", task=None, progress="0")
@@ -185,47 +208,16 @@ class Dag:
         for task in self.tasks.values():
             if not task.should_run():
                 # For IgnoreTasks
-                task.finished()
+                task.success()
                 continue
 
-            Logger().set_config(task=task.name)
-            task_start_ts = datetime.now()
-            if task.status != TaskStatus.READY:
-                task.failed("Task failed during setup. Skipping...")
-                failed.append(task.name)
-            elif not task.can_run():
-                logging.warn("SKIPPING")
+            status = self._run_task(command, task)
+            if status == TaskStatus.SKIPPED:
                 skipped.append(task.name)
-                task.skipped()
+            elif status in (TaskStatus.FAILED, TaskStatus.UNKNOWN) or status != TaskStatus.SUCCESS:
+                failed.append(task.name)
             else:
-                logging.debug("Starting")
-                task.executing()
-                try:
-                    if command == "compile":
-                        status = task.compile()
-                    elif command == "run":
-                        status = task.run()
-                    else:
-                        status = None
-                except Exception as e:
-                    logging.exception(e)
-
-                    status = None
-
-                if status is None:
-                    task.status = TaskStatus.UNKNOWN
-                    logging.error(
-                        f"Finished in an unknown state ({datetime.now() - task_start_ts})"
-                    )
-                    failed.append(task.name)
-                elif status != TaskStatus.FINISHED:
-                    logging.error(f"Failed status ({datetime.now() - task_start_ts})")
-                    failed.append(task.name)
-                else:
-                    logging.info(
-                        f"\u001b[32mSuccess ({datetime.now() - task_start_ts})\u001b[0m"
-                    )
-                    success.append(task.name)
+                success.append(task.name)
 
             tcounter += 1
             run_progress = str(round((tcounter) / ntasks * 100))

--- a/sayn/database/database.py
+++ b/sayn/database/database.py
@@ -76,7 +76,7 @@ class Database:
 
     # ETL steps
 
-    def get_table(self, table, schema, columns=None):
+    def get_table(self, table, schema, columns=None, required_existing=False):
         """Create a SQLAlchemy Table object. If columns is not None, fills up columns or checks the columns are present"""
         table_def = Table(table, self.metadata, schema=schema, extend_existing=True)
 
@@ -97,7 +97,8 @@ class Database:
                 if len(cols_in_table - cols_requested) > 0:
                     for column in cols_in_table - cols_requested:
                         table_def._columns.remove(table_def.columns[column])
-
+        elif required_existing:
+            return
         elif columns is not None:
             for column in columns:
                 table_def.append_column(column.copy())

--- a/sayn/database/postgresql.py
+++ b/sayn/database/postgresql.py
@@ -22,7 +22,8 @@ class Postgresql(Database):
         return q
 
     def create_table_ddl(self, table, schema, ddl, replace=False):
-        table = f"{schema+'.' if schema else ''}{table}"
+        table_name = table
+        table = f"{schema+'.' if schema else ''}{table_name}"
         columns = "\n    , ".join(
             [
                 (
@@ -54,7 +55,7 @@ class Postgresql(Database):
         q += f"CREATE TABLE {table} (\n      {columns}\n);\n"
         q += "\n".join(
             [
-                f"CREATE INDEX {name} ON {table}({', '.join(cols)});"
+                f"CREATE INDEX {table_name}_{name} ON {table}({', '.join(cols)});"
                 for name, cols in indexes.items()
             ]
         )
@@ -67,17 +68,27 @@ class Postgresql(Database):
         return f"DROP {table_or_view} IF EXISTS {table} CASCADE;"
 
     def move_table(self, src_table, src_schema, dst_table, dst_schema, ddl):
-        drop = (
-            f"DROP TABLE IF EXISTS {dst_schema+'.' if dst_schema else ''}{dst_table} CASCADE;"
-        )
+        drop = f"DROP TABLE IF EXISTS {dst_schema+'.' if dst_schema else ''}{dst_table} CASCADE;"
         rename = f"ALTER TABLE {src_schema+'.' if src_schema else ''}{src_table} RENAME TO {dst_table};"
         if dst_schema is not None:
             change_schema = f"ALTER TABLE {src_schema+'.' if src_schema else ''}{dst_table} SET SCHEMA {dst_schema};"
         else:
             change_schema = ""
-        pkey_alter = ""
-        if ddl is not None and 'columns' in ddl:
-            if len([c for c in ddl["columns"] if c.get("primary", False)]):
-                pkey_alter = f"ALTER INDEX {dst_schema+'.' if dst_schema else ''}{src_table}_pkey RENAME TO {dst_table}_pkey;"
 
-        return "\n".join((drop, rename, change_schema, pkey_alter))
+        idx_alter = []
+        if ddl is not None and "columns" in ddl:
+            # Change primary key name
+            if len([c for c in ddl["columns"] if c.get("primary", False)]):
+                idx_alter.append(
+                    f"ALTER INDEX {dst_schema+'.' if dst_schema else ''}{src_table}_pkey RENAME TO {dst_table}_pkey;"
+                )
+
+            # Change index names
+            for idx in [
+                idx for c in ddl["columns"] for idx in c.get("indexes", list())
+            ]:
+                idx_alter.append(
+                    f"ALTER INDEX {dst_schema+'.' if dst_schema else ''}{src_table}_{idx} RENAME TO {dst_table}_{idx};"
+                )
+
+        return "\n".join([drop, rename, change_schema] + idx_alter)

--- a/sayn/database/postgresql.py
+++ b/sayn/database/postgresql.py
@@ -1,3 +1,5 @@
+from itertools import groupby
+
 from .database import Database
 
 
@@ -7,3 +9,54 @@ class Postgresql(Database):
         connection_details = settings
         connection_details.pop("type")
         super().__init__(name, name_in_settings, connection_details)
+
+    def create_table_select(self, table, schema, select, replace=False, view=False):
+        table = f"{schema+'.' if schema else ''}{table}"
+        table_or_view = "VIEW" if view else "TABLE"
+
+        q = ""
+        if replace:
+            q += f"DROP {table_or_view} IF EXISTS {table};\n"
+        q += f"CREATE {table_or_view} {table} AS (\n{select}\n);"
+
+        return q
+
+    def create_table_ddl(self, table, schema, ddl, replace=False):
+        table = f"{schema+'.' if schema else ''}{table}"
+        columns = "\n    , ".join(
+            [
+                (
+                    f'{c["name"]} {c["type"]}'
+                    f'{" PRIMARY KEY" if c.get("primary", False) else ""}'
+                    f'{" NOT NULL" if c.get("not_null", False) else ""}'
+                )
+                for c in ddl["columns"]
+            ]
+        )
+        indexes = {
+            idx: [c[1] for c in cols]
+            for idx, cols in groupby(
+                sorted(
+                    [
+                        (idx, c["name"])
+                        for c in ddl["columns"]
+                        if "indexes" in c
+                        for idx in c["indexes"]
+                    ]
+                ),
+                lambda x: x[0],
+            )
+        }
+
+        q = ""
+        if replace:
+            q += f"DROP TABLE IF EXISTS {table};\n"
+        q += f"CREATE TABLE {table} (\n      {columns}\n);\n"
+        q += "\n".join(
+            [
+                f"CREATE INDEX {name} ON {table}({', '.join(cols)});"
+                for name, cols in indexes.items()
+            ]
+        )
+
+        return q

--- a/sayn/database/snowflake.py
+++ b/sayn/database/snowflake.py
@@ -40,10 +40,10 @@ class Snowflake(Database):
             self.engine.execute(f"USE {schema.split('.')[0]}")
         self.metadata.reflect(only=only, schema=schema, extend_existing=True)
 
-    def get_table(self, table, schema, columns=None):
+    def get_table(self, table, schema, columns=None, required_existing=False):
         """Create a SQLAlchemy Table object. If columns is not None, fills up columns or checks the columns are present"""
         schema = self._get_schema(schema)
-        return super(Snowflake, self).get_table(table, schema, columns)
+        return super(Snowflake, self).get_table(table, schema, columns, required_existing=required_existing)
 
     def move_table(self, src_table, src_schema, dst_table, dst_schema, ddl):
         drop = (

--- a/sayn/tasks/copy.py
+++ b/sayn/tasks/copy.py
@@ -2,7 +2,6 @@ import logging
 
 from .task import TaskStatus
 from .sql import SqlTask
-from ..utils import yaml
 
 
 class CopyTask(SqlTask):
@@ -127,10 +126,9 @@ class CopyTask(SqlTask):
             "source", default={"schema": None}
         )
 
-        if source["schema"] is None:
-            self.source_schema = None
-        elif isinstance(source["schema"], str):
-            self.source_schema = self.compile_property(source.pop("schema"))
+        self.schema = source.pop('schema', None)
+        if self.schema is not None and isinstance(self.schema, str):
+            self.schema = self.compile_property(self.schema)
         else:
             return self.failed('Optional property "schema" must be a string')
 

--- a/sayn/tasks/copy.py
+++ b/sayn/tasks/copy.py
@@ -8,85 +8,27 @@ from ..utils import yaml
 class CopyTask(SqlTask):
     def setup(self):
         self.db = self.sayn_config.default_db
-        self._setup_ddl()
 
+        status = self._setup_ddl(type_required=False)
         if self.ddl is None:
             # TODO full copy of table when ddl not specified
             return self.failed("DDL is required for copy tasks")
 
-        schema = yaml.Map(
-            {
-                "from": yaml.Map(
-                    {
-                        "db": yaml.Enum(self.sayn_config.dbs.keys()),
-                        yaml.Optional("schema"): yaml.NotEmptyStr(),
-                        "table": yaml.NotEmptyStr(),
-                    }
-                ),
-                "to": yaml.Map(
-                    {
-                        yaml.Optional("staging_schema"): yaml.NotEmptyStr(),
-                        yaml.Optional("schema"): yaml.NotEmptyStr(),
-                        "table": yaml.NotEmptyStr(),
-                    }
-                ),
-                yaml.Optional("incremental_key"): yaml.Enum(
-                    [c["name"] for c in self.ddl["columns"]]
-                ),
-                yaml.Optional("delete_key"): yaml.Enum(
-                    [c["name"] for c in self.ddl["columns"]]
-                ),
-            }
-        )
+        status = self._setup_source()
+        if status != TaskStatus.READY:
+            return status
 
-        try:
-            yaml.as_document(self._task_def, schema)
-        except yaml.ValidationError as e:
-            return self.failed(["Error in task definition", e])
+        status = self._setup_destination()
+        if status != TaskStatus.READY:
+            return status
 
-        self.from_db = self.sayn_config.dbs[self._task_def["from"]["db"]]
-        self.from_schema = self.compile_property(self._task_def["from"].get("schema"))
-        self.from_table = self.compile_property(self._task_def["from"]["table"])
+        status = self._setup_incremental()
+        if status != TaskStatus.READY:
+            return status
 
-        self.schema = self.compile_property(self._task_def["to"].get("schema"))
-        self.table = self.compile_property(self._task_def["to"]["table"])
-
-        self.staging_schema = self.compile_property(
-            self._task_def["to"].get("staging_schema")
-        )
-        self.staging_table = "sayn_tmp_" + self.table
-
-        self.incremental_key = self._task_def.get("incremental_key")
-        self.delete_key = self._task_def.get("delete_key")
-
-        if not (
-            (self.incremental_key is None and self.delete_key is None)
-            or (not self.incremental_key is None and not self.delete_key is None)
-        ):
-            return self.failed(
-                f'Incremental copy requires both "delete_key" and "incremental_key"'
-            )
-
-        self.from_table_def = self.from_db.get_table(
-            self.from_table,
-            self.from_schema,
-            columns=[c["name"] for c in self.ddl["columns"]],
-        )
-
-        if self.from_table_def is None or not self.from_table_def.exists():
-            return self.failed(
-                (
-                    f"Table \"{self.from_schema+'.' if self.from_schema is not None else ''}{self.from_table}\""
-                    f" does not exists or columns don't match with DDL specification"
-                )
-            )
-
-        # Fill up column types from the source table
-        for column in self.ddl["columns"]:
-            if "type" not in column:
-                column["type"] = self.from_table_def.columns[
-                    column["name"]
-                ].type.compile()
+        status = self._setup_table_columns()
+        if status != TaskStatus.READY:
+            return status
 
         status = self._setup_sql()
         if status != TaskStatus.READY:
@@ -94,32 +36,28 @@ class CopyTask(SqlTask):
 
         return self.ready()
 
-    def _setup_ddl(self):
-        return super()._setup_ddl(type_required=False)
-
     def run(self):
         logging.debug("Writting query on disk")
         status = self._write_queries()
-        if status != TaskStatus.FINISHED:
+        if status != TaskStatus.SUCCESS:
             return self.failed()
 
         logging.debug("Running SQL")
         try:
             step = "last_incremental_value"
+            last_incremental_value = None
             if self.compiled[step] is not None:
                 res = self.db.select(self.compiled[step])
                 res = list(res[0].values())[0]
-                if res is None:
-                    last_incremental_value = None
-                else:
+                if res is not None:
                     last_incremental_value = {'incremental_value': res}
 
             step = "get_data"
-            data = self.from_db.select(self.compiled[step], last_incremental_value)
+            data = self.source_db.select(self.compiled[step], last_incremental_value)
 
             if len(data) == 0:
                 logging.debug('Nothing to load')
-                return self.finished()
+                return self.success()
 
             step = "create_load_table"
             if self.compiled[step] is not None:
@@ -138,48 +76,115 @@ class CopyTask(SqlTask):
                 logging.debug(f"Query: {self.compiled[step]}")
             return self.failed()
 
-        return self.finished()
+        return self.success()
 
     def compile(self):
         status = self._write_queries()
-        if status != TaskStatus.FINISHED:
+        if status != TaskStatus.SUCCESS:
             return self.failed()
         else:
-            return self.finished()
+            return self.success()
 
     def _write_queries(self):
         try:
 
             step = "last_incremental_value"
             if self.compiled[step] is not None:
-                self.write_query(self.compiled[step], suffix=step)
+                self._write_query(self.compiled[step], suffix=step)
 
             step = "get_data"
-            self.write_query(self.compiled[step], suffix=step)
+            self._write_query(self.compiled[step], suffix=step)
 
             step = "create_load_table"
             if self.compiled[step] is not None:
-                self.write_query(self.compiled[step], suffix=step)
+                self._write_query(self.compiled[step], suffix=step)
 
             step = "finish"
             if self.compiled[step] is not None:
-                self.write_query(self.compiled[step], suffix=step)
+                self._write_query(self.compiled[step], suffix=step)
         except Exception as e:
             return self.failed((f'Error saving query "{step}" on disk', e))
 
-        return TaskStatus.FINISHED
+        return TaskStatus.SUCCESS
+
+    # Task property methods
+
+    def _setup_incremental(self):
+        # Type of materialisation
+        self.delete_key = self._pop_property("delete_key")
+        self.incremental_key = self._pop_property("incremental_key")
+        
+        if (self.delete_key is None) != (self.incremental_key is None):
+            return self.failed(
+                f'Incremental copy requires both "delete_key" and "incremental_key"'
+            )
+
+        return TaskStatus.READY
+
+    def _setup_source(self):
+        # Source property indicating the table this will create
+        source = self._pop_property(
+            "source", default={"schema": None}
+        )
+
+        if source["schema"] is None:
+            self.source_schema = None
+        elif isinstance(source["schema"], str):
+            self.source_schema = self.compile_property(source.pop("schema"))
+        else:
+            return self.failed('Optional property "schema" must be a string')
+
+        if set(source.keys()) != set(["db", "table"]) or source['db'] is None or source['table'] is None:
+            return self.failed(
+                'Source requires "table" and "db" fields. Optional field: "schema".'
+            )
+        else:
+            source_db_name = self.compile_property(source.pop("db"))
+            self.source_table = self.compile_property(source.pop("table"))
+
+        if source_db_name not in self.sayn_config.dbs:
+            return self.failed(f'{source_db_name} is not a valid vallue for "db" in "source"')
+        else:
+            self.source_db = self.sayn_config.dbs[source_db_name]
+
+        return TaskStatus.READY
+
+    def _setup_table_columns(self):
+        self.source_table_def = self.source_db.get_table(
+            self.source_table,
+            self.source_schema,
+            columns=[c["name"] for c in self.ddl["columns"]],
+            required_existing=True
+        )
+
+        if self.source_table_def is None or not self.source_table_def.exists():
+            return self.failed(
+                (
+                    f"Table \"{self.source_schema+'.' if self.source_schema is not None else ''}{self.source_table}\""
+                    f" does not exists or columns don't match with DDL specification"
+                )
+            )
+
+        # Fill up column types from the source table
+        for column in self.ddl["columns"]:
+            if "type" not in column:
+                column["type"] = self.source_table_def.columns[
+                    column["name"]
+                ].type.compile()
+
+        return TaskStatus.READY
 
     # Utility methods
 
     def _setup_sql(self):
-        self.to_table_def = self.db.get_table(
-            self.table, self.schema, columns=self.from_table_def.columns
+        self.destination_table_def = self.db.get_table(
+            self.table, self.schema, columns=self.source_table_def.columns
         )
 
-        if self.to_table_def is None:
-            return self.failed()
+        if self.destination_table_def is None:
+            return self.failed('Error detecting destination table')
 
-        if not self.to_table_def.exists():
+        if not self.destination_table_def.exists():
             # Full load:
             # Create final table directly and load there
             self.load_table = self.table
@@ -189,9 +194,9 @@ class CopyTask(SqlTask):
             )
             self.compiled = {
                 "last_incremental_value": None,
-                "get_data": self.from_db.get_data(
-                    self.from_table,
-                    self.from_schema,
+                "get_data": self.source_db.get_data(
+                    self.source_table,
+                    self.source_schema,
                     [c["name"] for c in self.ddl["columns"]],
                 ),
                 "create_load_table": f"-- Create table\n{create_load_table}",
@@ -200,20 +205,20 @@ class CopyTask(SqlTask):
 
         elif self.incremental_key is None:
             # Table exists and it's not an incremental load:
-            # Create staging table, load there and then move
-            self.load_table = self.staging_table
-            self.load_schema = self.staging_schema
+            # Create temporary table, load there and then move
+            self.load_table = self.tmp_table
+            self.load_schema = self.tmp_schema
             create_load_table = self.db.create_table_ddl(
                 self.load_table, self.load_schema, self.ddl, replace=True
             )
             self.compiled = {
                 "last_incremental_value": None,
-                "get_data": self.from_db.get_data(
-                    self.from_table,
-                    self.from_schema,
+                "get_data": self.source_db.get_data(
+                    self.source_table,
+                    self.source_schema,
                     [c["name"] for c in self.ddl["columns"]],
                 ),
-                "create_load_table": f"-- Create staging table\n{create_load_table}",
+                "create_load_table": f"-- Create temporary table\n{create_load_table}",
                 "finish": self.db.move_table(
                     self.load_table,
                     self.load_schema,
@@ -224,9 +229,9 @@ class CopyTask(SqlTask):
             }
         elif self.delete_key is not None:
             # Incremental load:
-            # Create staging table, load there and then merge
-            self.load_table = self.staging_table
-            self.load_schema = self.staging_schema
+            # Create temporary table, load there and then merge
+            self.load_table = self.tmp_table
+            self.load_schema = self.tmp_schema
             create_load_table = self.db.create_table_ddl(
                 self.load_table, self.load_schema, self.ddl, replace=True
             )
@@ -234,13 +239,13 @@ class CopyTask(SqlTask):
                 "last_incremental_value": self.db.get_max_value(
                     self.table, self.schema, self.incremental_key
                 ),
-                "get_data": self.from_db.get_data(
-                    self.from_table,
-                    self.from_schema,
+                "get_data": self.source_db.get_data(
+                    self.source_table,
+                    self.source_schema,
                     [c["name"] for c in self.ddl["columns"]],
                     incremental_key=self.incremental_key,
                 ),
-                "create_load_table": f"-- Create staging table\n{create_load_table}",
+                "create_load_table": f"-- Create temporary table\n{create_load_table}",
                 "finish": self.db.merge_tables(
                     self.load_table,
                     self.load_schema,

--- a/sayn/tasks/creator.py
+++ b/sayn/tasks/creator.py
@@ -17,47 +17,49 @@ def create_python(name, task):
         task_object.failed()
         return task_object
 
-    return fail_creation(name, task)
+    class_str = None
+    if "preset" in task:
+        if "preset" in task["preset"]:
+            if "class" in task["preset"]["preset"]:
+                class_str = task["preset"]["preset"].pop("class")
 
-    module = task.data.get("module")
-    if module is None:
-        if 'preset' in task:
-            if 'module' in task.preset:
-                pass
-            module = group.get("module")
-        if module is None:
-            logging.error(f'Missing module for task "{name}"')
-            return fail_creation(name, task, group, model)
-        else:
-            module = module.data
+        if "class" in task["preset"]:
+            class_str = task["preset"].pop("class")
 
-    class_name = task.data.get("class")
-    if class_name is None:
-        if group is not None:
-            class_name = group.get("class")
-        if class_name is None:
-            logging.error(f'Missing class for task "{name}"')
-            return fail_creation(name, task, group, model)
-        else:
-            class_name = class_name.data
+    if "class" in task:
+        class_str = task.pop("class")
 
-    try:
-        task_module = importlib.import_module(f'python_tasks.{module}')
-    except:
-        logging.error(f'Module "{module}" not found in python folder')
+    if class_str is None:
+        logging.error('Missing required "class" field in python task')
+        return fail_creation(name, task)
 
-        return fail_creation(name, task, group, model)
+    module_str = ".".join(class_str.split(".")[:-1])
+    class_str = class_str.split(".")[-1]
+
+    if len(module_str) > 0:
+        try:
+            task_module = importlib.import_module(f"sayn_python_tasks.{module_str}")
+        except:
+            logging.error(f'Module "{module_str}" not found in python folder')
+            return fail_creation(name, task)
+    else:
+        task_module = importlib.import_module("sayn_python_tasks")
 
     try:
-        klass = getattr(task_module, class_name)
+        klass = getattr(task_module, class_str)
     except:
+        module_file_name = (
+            module_str.replace(".", "/") if len(module_str) > 0 else "__init__"
+        )
         logging.error(
-            f'No task class "{class_name}" found in "python/{module.replace(".", "/")}.py"'
+            f'No task class "{class_str}" found in "python/{module_file_name}.py"'
         )
 
-        return fail_creation(name, task, group, model)
+        return fail_creation(name, task)
 
-    task_object = klass(name, task, group, model)
+    # Create object and ensure there's no extra properties
+    task_object = klass(name, task)
+    task_object._check_extra_fields()
     return task_object
 
 
@@ -70,8 +72,7 @@ def create_task(name, type, task, ignore):
         "sql": SqlTask,
         "autosql": AutoSqlTask,
         "copy": CopyTask,
-        # TODO fixes to python tasks
-        "python": IgnoreTask, #create_python,
+        "python": create_python,
     }
 
     if ignore:

--- a/sayn/tasks/dummy.py
+++ b/sayn/tasks/dummy.py
@@ -10,8 +10,8 @@ class DummyTask(Task):
 
     def compile(self):
         logging.debug("DummyTask compiling")
-        return self.finished()
+        return self.success()
 
     def run(self):
         logging.debug("DummyTask running.")
-        return self.finished()
+        return self.success()

--- a/sayn/tasks/ignore.py
+++ b/sayn/tasks/ignore.py
@@ -13,8 +13,8 @@ class IgnoreTask(Task):
 
     def compile(self):
         logging.debug("IgnoreTask compiling")
-        return self.finished()
+        return self.success()
 
     def run(self):
         logging.debug("IgnoreTask running.")
-        return self.finished()
+        return self.success()

--- a/sayn/tasks/python.py
+++ b/sayn/tasks/python.py
@@ -14,8 +14,8 @@ class PythonTask(Task):
 
     def compile(self):
         logging.debug("PythonTask compiling")
-        return self.finished()
+        return self.success()
 
     def run(self):
         logging.debug("PythonTask running.")
-        return self.finished()
+        return self.success()

--- a/sayn/tasks/python.py
+++ b/sayn/tasks/python.py
@@ -4,8 +4,10 @@ from .task import Task
 
 
 class PythonTask(Task):
-    def __init__(self, name, task, group, model):
-        super(PythonTask, self).__init__(name, task, group, model)
+    def __init__(self, name, task):
+        super(PythonTask, self).__init__(name, task)
+
+        # Add some convenient properties
         self.default_db = self.sayn_config.default_db
 
     def setup(self):

--- a/sayn/tasks/sql.py
+++ b/sayn/tasks/sql.py
@@ -74,17 +74,15 @@ class SqlTask(Task):
             "destination", default={"tmp_schema": None, "schema": None}
         )
 
-        if destination["tmp_schema"] is None:
-            self.tmp_schema = None
-        elif isinstance(destination["tmp_schema"], str):
-            self.tmp_schema = self.compile_property(destination.pop("tmp_schema"))
-        else:
+        self.tmp_schema = destination.pop('tmp_schema', None)
+        if self.tmp_schema is not None and isinstance(self.tmp_schema, str):
+            self.tmp_schema = self.compile_property(self.tmp_schema)
+        elif self.tmp_schema is not None:
             return self.failed('Optional property "tmp_schema" must be a string')
 
-        if destination["schema"] is None:
-            self.schema = None
-        elif isinstance(destination["schema"], str):
-            self.schema = self.compile_property(destination.pop("schema"))
+        self.schema = destination.pop('schema', None)
+        if self.schema is not None and isinstance(self.schema, str):
+            self.schema = self.compile_property(self.schema)
         else:
             return self.failed('Optional property "schema" must be a string')
 

--- a/sayn/tasks/sql.py
+++ b/sayn/tasks/sql.py
@@ -124,7 +124,7 @@ class SqlTask(Task):
     def _write_query(self, query, suffix=None):
         path = Path(
             self.sayn_config.compile_path,
-            self.group,
+            self.dag,
             Path(f"{self.name}{'_'+suffix if suffix is not None else ''}.sql"),
         )
 

--- a/sayn/tasks/sql.py
+++ b/sayn/tasks/sql.py
@@ -7,8 +7,13 @@ from ..utils import yaml
 
 class SqlTask(Task):
     def setup(self):
-        self.template = self.get_query()
+        self.db = self.sayn_config.default_db
 
+        status = self._setup_file_name()
+        if status != TaskStatus.READY:
+            return status
+
+        self.template = self._get_query_template()
         if self.template is None:
             return self.failed()
 
@@ -17,13 +22,11 @@ class SqlTask(Task):
         except Exception as e:
             return self.failed(f"Error compiling template\n{e}")
 
-        self.db = self.sayn_config.default_db
-
-        return self.ready()
+        return self._check_extra_fields()
 
     def run(self):
         logging.debug("Writting query on disk")
-        self.write_query(self.compiled)
+        self._write_query(self.compiled)
         if self.status == TaskStatus.FAILED:
             return self.failed()
 
@@ -34,57 +37,74 @@ class SqlTask(Task):
         except Exception as e:
             return self.failed(("Error running query", e, f"Query: {self.compiled}"))
 
-        return self.finished()
+        return self.success()
 
     def compile(self):
         try:
-            self.write_query(self.compiled)
+            self._write_query(self.compiled)
         except Exception as e:
             return self.failed(("Error saving query on disk", e))
 
-        return self.finished()
+        return self.success()
 
-    # Utility methods
+    # Task property methods
 
-    def write_query(self, query, suffix=None):
-        path = Path(
-            self.sayn_config.compile_path,
-            Path(f"{self.name}{'_'+suffix if suffix is not None else ''}.sql"),
-        )
+    def _setup_file_name(self):
+        # file_name pointint to the code for the sql task
+        self.file_name = self._pop_property("file_name")
+        if self.file_name is None:
+            return self.failed('"file_name" is a required field')
+        else:
+            self.file_name = self.compile_property(self.file_name)
 
-        # Ensure the path exists and it's empty
-        path.parent.mkdir(parents=True, exist_ok=True)
-        if path.exists():
-            path.unlink()
+        return TaskStatus.READY
 
-        path.write_text(str(query))
-
-    def get_query(self):
-        logging.debug("Setting up SQL Task")
-
-        if "file_name" not in self._task_def:
-            logging.error('"file_name" is a required field')
-            return
-
-        path = Path(
-            self.sayn_config.sql_path,
-            self.compile_property(self._task_def["file_name"]),
-        )
+    def _get_query_template(self):
+        path = Path(self.sayn_config.sql_path, self.compile_property(self.file_name))
 
         if not path.is_file():
             logging.error(f"{path}: file not found")
             return
 
-        logging.debug("Compiling sql")
-
         return self.sayn_config.jinja_env.get_template(str(path))
 
+    def _setup_destination(self):
+        # Destination property indicating the table this will create
+        destination = self._pop_property(
+            "destination", default={"tmp_schema": None, "schema": None}
+        )
+
+        if destination["tmp_schema"] is None:
+            self.tmp_schema = None
+        elif isinstance(destination["tmp_schema"], str):
+            self.tmp_schema = self.compile_property(destination.pop("tmp_schema"))
+        else:
+            return self.failed('Optional property "tmp_schema" must be a string')
+
+        if destination["schema"] is None:
+            self.schema = None
+        elif isinstance(destination["schema"], str):
+            self.schema = self.compile_property(destination.pop("schema"))
+        else:
+            return self.failed('Optional property "schema" must be a string')
+
+        if set(destination.keys()) == set(["table"]) and destination["table"] is not None:
+            self.table = self.compile_property(destination.pop("table"))
+            self.tmp_table = f"sayn_tmp_{self.table}"
+        else:
+            return self.failed(
+                'Destination requires "table" field. Optional fields: tmp_schema and schema.'
+            )
+
+        return TaskStatus.READY
+
     def _setup_ddl(self, type_required=True):
-        ddl = self._task_def.pop('ddl', None)
+        ddl = self._pop_property("ddl")
         if ddl is not None:
             if isinstance(ddl, str):
                 # TODO external file not implemented
-                parsed = yaml.load(self.compile_property(ddl))
+                #parsed = yaml.load(self.compile_property(ddl))
+                raise ValueError('External file for ddl not implemented')
             else:
                 parsed = yaml.as_document(ddl)
 
@@ -98,3 +118,19 @@ class SqlTask(Task):
         else:
             self.ddl = None
             return TaskStatus.READY
+
+    # Utility methods
+
+    def _write_query(self, query, suffix=None):
+        path = Path(
+            self.sayn_config.compile_path,
+            self.group,
+            Path(f"{self.name}{'_'+suffix if suffix is not None else ''}.sql"),
+        )
+
+        # Ensure the path exists and it's empty
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if path.exists():
+            path.unlink()
+
+        path.write_text(str(query))

--- a/sayn/tasks/task.py
+++ b/sayn/tasks/task.py
@@ -22,7 +22,7 @@ class Task(object):
 
         self.name = name
         self.type = task.pop("type")
-        self.group = task.pop("group")
+        self.dag = task.pop("dag")
         self.tags = task.pop("tags", list())
         self.parents = task.pop("parents", list())
 

--- a/sayn/tasks/task.py
+++ b/sayn/tasks/task.py
@@ -9,7 +9,7 @@ class TaskStatus(Enum):
     SETTING_UP = 0
     READY = 1
     EXECUTING = 2
-    FINISHED = 3
+    SUCCESS = 3
     FAILED = 4
     SKIPPED = 5
     IGNORED = 6
@@ -17,50 +17,20 @@ class TaskStatus(Enum):
 
 class Task(object):
     # Init functions
-    def __init__(self, name, task, group, model):
+    def __init__(self, name, task):
         self.sayn_config = Config()
 
         self.name = name
-        self.model = model
+        self.type = task.pop("type")
+        self.group = task.pop("group")
+        self.tags = task.pop("tags", list())
+        self.parents = task.pop("parents", list())
 
-        self._task_def_start_line = task.start_line
-        self._task_def_end_line = task.end_line
-        if group is not None:
-            self._group_def_start_line = group.start_line
-            self._group_def_end_line = group.end_line
-        else:
-            self._group_def_start_line = None
-
-        _task_def = task.data
-        if group is not None:
-            # Merge group into task definition
-            for prop, val in group.data.items():
-                if prop not in _task_def:
-                    _task_def[prop] = val
-                elif prop == "parameters":
-                    for name, param in val.items():
-                        if name not in _task_def["parameters"]:
-                            _task_def["parameters"][name] = val[name]
-                elif prop == "parents":
-                    if not isinstance(val, list):
-                        self.failed(
-                            f"Parents need to be a list in group {_task_def['group']}"
-                        )
-                        return
-                    _task_def["parents"] = list(
-                        set(_task_def.get("parents", list()) + val)
-                    )
-
-        self.type = _task_def.pop("type")
-        self.group = _task_def.pop("group", None)
-        self.tags = _task_def.pop("tags", list())
-        self.parents = _task_def.pop("parents", list())
-
-        self.parameters = _task_def.pop("parameters", dict())
+        self.parameters = task.pop("parameters", dict())
         for name, value in self.parameters.items():
             self.parameters[name] = self.compile_property(self.parameters[name])
 
-        self._task_def = _task_def
+        self._task_def = task
 
         self.setting_up()
 
@@ -68,7 +38,69 @@ class Task(object):
         """Replaces the parents list with the task objects"""
         self.parents = [tasks[p] for p in self.parents]
 
-    # Utility functions
+    # Properties methods
+
+    def _check_extra_fields(self):
+        # Cleanup preset
+        if 'preset' in self._task_def:
+            if 'preset' in self._task_def['preset']:
+                if len(self._task_def['preset']['preset']) == 0:
+                    # Clean nested preset if possible
+                    del self._task_def['preset']['preset']
+
+            if len(self._task_def['preset']) == 0:
+                # If the nested preset is empty, clean the outer one if possible
+                del self._task_def['preset']
+
+        if len(self._task_def) > 0:
+            return self.failed(
+                "Invalid properties for {}: {}".format(
+                    self.type, ", ".join(self._task_def.keys())
+                )
+            )
+        else:
+            return self.ready()
+
+    def _pop_property(self, property, default=None):
+        """Navigates the task definition and finds the first occurrence of the named property.
+           First it checks in the task, then the preset and finally the nested preset of the preset
+           (the project.yaml preset).
+           Returns None if not found anywhere"""
+
+        def merge_value(value, new_value):
+            if value is None:
+                return new_value
+            elif not isinstance(new_value, type(value)):
+                raise ValueError(type(new_value))
+            elif isinstance(value, dict):
+                value.update(new_value)
+            elif isinstance(value, list):
+                value.extend([v for v in new_value if v not in value])
+            else:
+                value = new_value
+
+            return value
+
+        value = default
+
+        # Extract the value from the deepest level of nesting first and go outwards
+        # We always remove it from the _task_def 
+        if 'preset' in self._task_def:
+            if 'preset' in self._task_def['preset']:
+                if property in self._task_def['preset']['preset']:
+                    new_value = self._task_def['preset']['preset'].pop(property)
+                    value = merge_value(value, new_value)
+
+            if property in self._task_def['preset']:
+                new_value = self._task_def['preset'].pop(property)
+                value = merge_value(value, new_value)
+
+        if property in self._task_def:
+            new_value = self._task_def.pop(property)
+            value = merge_value(value, new_value)
+
+        return value
+
     def compile_property(self, value):
         if value is None:
             return
@@ -96,7 +128,7 @@ class Task(object):
         if self.status != TaskStatus.READY:
             return False
         for p in self.parents:
-            if p.status not in (TaskStatus.IGNORED, TaskStatus.FINISHED):
+            if p.status not in (TaskStatus.IGNORED, TaskStatus.SUCCESS):
                 return False
         return True
 
@@ -125,8 +157,8 @@ class Task(object):
         self.status = TaskStatus.EXECUTING
         return self.status
 
-    def finished(self):
-        self.status = TaskStatus.FINISHED
+    def success(self):
+        self.status = TaskStatus.SUCCESS
         return self.status
 
     def failed(self, messages=None):

--- a/sayn/utils/yaml.py
+++ b/sayn/utils/yaml.py
@@ -1,6 +1,4 @@
-import sys
 import logging
-from pathlib import Path
 
 from strictyaml import (
     Bool,
@@ -18,6 +16,12 @@ from strictyaml import (
     EmptyDict,
 )
 from strictyaml import YAMLValidationError as ValidationError
+
+
+class Identifier(Regex):
+    def __init__(self):
+        self._regex = r"^[a-zA-Z0-9][-_a-zA-Z0-9]+$"
+        self._matching_message = "when expecting a valid identifier string"
 
 
 class NotEmptyStr(Regex):


### PR DESCRIPTION
### This PR:

* Renames the following:
  * `models.yaml` > `project.yaml`
  * `groups` > `presets`
  * `models` > `dags`
  * `to` > `destination` (copy and autosql task types)
  * `from` > `source` (copy task types)
  * `staging_schema` > `tmp_schema`  (copy and autosql task types)
* Alows specifying `presets` in `project.yaml`
* Presets in the dags can reference a preset in `project.yaml` with the `preset` property
* Compilation output is saved in a folder named as the dag within the compile folder
* `module` in python tasks is deprecated and the `class` should now point at the full class path (ie: `class: my_module.MyTask` points at a sayn python task called MyTask within `python/my_module.py`
* Task and preset names are restricted by a regex `^[a-zA-Z0-9][-_a-zA-Z0-9]+$`