### PR TITLE
Fixes issue when task is not in query and parents fail

### DIFF
--- a/sayn/core/app.py
+++ b/sayn/core/app.py
@@ -165,22 +165,29 @@ class App:
 
     def execute_dag(self, command):
         # Execution of relevant tasks
-        tasks = {k: v for k, v in self.tasks.items() if v.in_query}
-        self.tracker.start_stage(command, tasks=list(tasks.keys()))
+        tasks_in_query = {k: v for k, v in self.tasks.items() if v.in_query}
+        self.tracker.start_stage(command, tasks=list(tasks_in_query.keys()))
 
-        for task_name, task in tasks.items():
-            task.tracker._report_event("start_stage")
-            start_ts = datetime.now()
+        for task_name, task in self.tasks.items():
+            # We force the run/compile so that the skipped status can be calculated,
+            # but we only report if the task is in the query
             if task.in_query:
-                if command == "run":
-                    result = task.run()
-                else:
-                    result = task.compile()
-            task.tracker._report_event(
-                "finish_stage", duration=datetime.now() - start_ts, result=result
-            )
+                task.tracker._report_event("start_stage")
+                start_ts = datetime.now()
 
-        self.tracker.finish_current_stage(tasks={k: v.status for k, v in tasks.items()})
+            if command == "run":
+                result = task.run()
+            else:
+                result = task.compile()
+
+            if task.in_query:
+                task.tracker._report_event(
+                    "finish_stage", duration=datetime.now() - start_ts, result=result
+                )
+
+        self.tracker.finish_current_stage(
+            tasks={k: v.status for k, v in tasks_in_query.items()}
+        )
 
         self.finish_app()
 

--- a/sayn/logging/log_formatter.py
+++ b/sayn/logging/log_formatter.py
@@ -238,7 +238,7 @@ class LogFormatter:
                 [f"{p} ({s.value})" for p, s in error.details["failed_parents"].items()]
             )
             message = self.warn(
-                f"Skipping due to parent errors: {parents} ({duration})"
+                f"Skipping due to ancestors errors: {parents} ({duration})"
             )
 
         elif error.code == "setup_error":

--- a/sayn/logging/log_formatter.py
+++ b/sayn/logging/log_formatter.py
@@ -234,7 +234,12 @@ class LogFormatter:
 
         elif error.code == "parent_errors":
             level = "warning"
-            message = self.warn(f"Skipping due to parent errors ({duration})")
+            parents = ", ".join(
+                [f"{p} ({s.value})" for p, s in error.details["failed_parents"].items()]
+            )
+            message = self.warn(
+                f"Skipping due to parent errors: {parents} ({duration})"
+            )
 
         elif error.code == "setup_error":
             if error.details["status"].value == "skipped":

--- a/sayn/tasks/__init__.py
+++ b/sayn/tasks/__init__.py
@@ -77,9 +77,11 @@ class Task:
         """
         return Ok()
 
-    def fail(self, msg):
+    def fail(self, msg=None):
         """Returned on failure in any stage
         """
+        if msg is None:
+            msg = 'Unknown error. Use `self.fail("Error message")` in python tasks for more details.'
         return Err("tasks", "task_fail", message=msg)
 
     # Logging methods

--- a/sayn/tasks/task_wrapper.py
+++ b/sayn/tasks/task_wrapper.py
@@ -132,14 +132,15 @@ class TaskWrapper:
 
         self.in_query = in_query
 
+        # Check the parents are in a good state
+        result = self.check_skip()
+        if result.is_err or result.value == TaskStatus.SKIPPED:
+            return result
+
         if not in_query:
             self.status = TaskStatus.NOT_IN_QUERY
             return Ok()
         else:
-            # Check the parents are in a good state
-            result = self.check_skip()
-            if result.is_err:
-                return result
 
             # Instantiate the Task runner object
 


### PR DESCRIPTION
Using master, with the following definition of a project:
```
tasks:
  task1:
    type: incorrect_type
  task2:
    type: dummy
    parents:
      - task1
  task3:
    type: dummy
    parents:
      - task2
```

Running `sayn run` will fail `task1` and skip `task2` and `task3`.
Running `sayn run -x task2` will fail `task1` and `task3`, but I think `task3` should be skipped.