### PR TITLE
DDL primary key fix & DB API revamp

### DIFF
--- a/docs/databases/overview.md
+++ b/docs/databases/overview.md
@@ -67,8 +67,7 @@ Databases and other credentials defined in the SAYN project are available to Pyt
 gives you access to the default database declared in `project.yaml`.
 
 The [database python class](../api/database.md) provides several methods and properties to make it
-easier to work with python tasks. For example, `self.default_db.engine` can be used to to call 
-`DataFrame.read_sql` from pandas, but also provides some other convenient methods.
+easier to work with python tasks. For example you can easily read or load data with `self.default_db` (see example below) or use `self.default_db.engine` to call `DataFrame.read_sql` from pandas.
 
 !!! example "Example PythonTask"
     ``` python hl_lines="5"
@@ -76,16 +75,7 @@ easier to work with python tasks. For example, `self.default_db.engine` can be u
 
     class TaskPython(PythonTask):
         def run(self):
-            data = self.default_db.select("SELECT * FROM test_table")
+            data = self.default_db.read_data("SELECT * FROM test_table")
 
             # do something with that data
     ```
-
-## Database class
-
-::: sayn.database.Database
-    selection:
-      members:
-        - execute
-        - select
-        - load_data

--- a/docs/tasks/autosql.md
+++ b/docs/tasks/autosql.md
@@ -85,14 +85,18 @@ In order to make the `SELECT` statement incremental, SAYN provides the following
 
 ## Defining DDLs
 
-Additionally, autosql tasks support the definition of optional DDL that will be used when creating the table.
-Each supported database might have specific DDL related to it, but in general the following is supported:
+Autosql tasks support the definition of optional DDL. Each DDL entry is independent to others (you can define only DDLs which are relevant to you).
 
-* columns: the list of columns as well as their type. If used, SAYN will enforce the types specified.
+!!! attention
+      Each supported database might have specific DDL related to it. Below are the DDLs that SAYN supports across all databases. For DDLs related to specific databases see the database-specific pages.
+
+### ALTER TABLE DDLs
+
+The following DDLs will be issued by SAYN with `ALTER TABLE` statements:
+
 * indexes: the indexes to add on the table.
-  * primary_key: this should be added in the indexes section using the `primary_key` name for the index.
-* permissions: the permissions you want to give to each role. You should map each role to the rights
-  you want to grant separated by commas (e.g. SELECT, DELETE).
+* primary_key: this should be added in the indexes section using the `primary_key` name for the index.
+* permissions: the permissions you want to give to each role. You should map each role to the rights you want to grant separated by commas (e.g. SELECT, DELETE).
 
 !!! example "autosql with DDL"
     ```yaml
@@ -115,6 +119,48 @@ Each supported database might have specific DDL related to it, but in general th
           idx1:
             columns:
               - column1
+        permissions:
+          role_name: SELECT
+    ...
+    ```
+
+### CREATE TABLE DDLs
+
+SAYN also lets you control the CREATE TABLE statement if you need more specification. This is done with:
+
+* columns: the list of columns including their definitions.
+
+`columns` can define the following attributes:
+
+* name: the column name.
+* type: the column type.
+* primary: set to `True` if the column is part of the primary key.
+* unique: set to `True` to enforce a unique constraint on the column.
+* not_null: set to `True` to enforce a non null constraint on the column.
+
+!!! Attention
+    If the a primary key is defined in both the `columns` and `indexes` DDL entries, the primary key will be set as part of the `CREATE TABLE` statement only.
+
+!!! example "autosql with columns DDL"
+    ```yaml
+    ...
+
+    task_autosql:
+      type: autosql
+      file_name: task_autosql.sql
+      materialisation: table
+      destination:
+        tmp_schema: analytics_staging
+        schema: analytics_models
+        table: task_autosql
+      ddl:
+        columns:
+          - name: x
+            type: int
+            primary: True
+          - name: y
+            type: varchar
+            unique: True
         permissions:
           role_name: SELECT
     ...

--- a/docs/tasks/sql.md
+++ b/docs/tasks/sql.md
@@ -3,7 +3,7 @@
 ## About
 
 The `sql` task lets you execute a SQL script with one or many statements. This is useful for
-executing `UPDATE` statments for example, that wouldn't be covered by `autosql`.
+executing `UPDATE` statements for example, that wouldn't be covered by `autosql`.
 
 ## Defining `sql` tasks
 

--- a/sayn/database/redshift.py
+++ b/sayn/database/redshift.py
@@ -134,10 +134,10 @@ class Redshift(Database):
 
         return table_attributes + "\n"
 
-    def create_table_select(
+    def _create_table_select(
         self, table, schema, select, view=False, ddl=dict(), execute=True
     ):
-        """Returns SQL code for a create table from a select statment
+        """Returns SQL code for a create table from a select statement
         """
         table = f"{schema+'.' if schema else ''}{table}"
         table_or_view = "VIEW" if view else "TABLE"
@@ -154,8 +154,8 @@ class Redshift(Database):
 
         return q
 
-    def create_table_ddl(self, table, schema, ddl, execute=False):
-        """Returns SQL code for a create table from a select statment
+    def _create_table_ddl(self, table, schema, ddl, execute=False):
+        """Returns SQL code for a create table from a select statement
         """
         if len(ddl["columns"]) == 0:
             raise DBError(

--- a/sayn/database/snowflake.py
+++ b/sayn/database/snowflake.py
@@ -31,7 +31,7 @@ class Snowflake(Database):
         conn.connection.commit()
         conn.connection.close()
 
-    def move_table(
+    def _move_table(
         self, src_table, src_schema, dst_table, dst_schema, ddl, execute=False
     ):
         drop = (

--- a/sayn/tasks/base_sql.py
+++ b/sayn/tasks/base_sql.py
@@ -17,7 +17,7 @@ class BaseSqlTask(Task):
         # For incremental loads, manipulate the "Merge" steps depending on whether
         # the target table exists or not. This is done so we can delay the introspection
         if "Merge" in self.steps and self.run_arguments["command"] == "run":
-            self.target_table_exists = self.default_db.table_exists(
+            self.target_table_exists = self.default_db._table_exists(
                 self.table, self.schema
             )
 
@@ -42,7 +42,7 @@ class BaseSqlTask(Task):
         return Ok()
 
     def create_table_ddl(self, tmp_table, tmp_schema, ddl, execute):
-        q = self.default_db.create_table_ddl(tmp_table, tmp_schema, ddl, execute)
+        q = self.default_db._create_table_ddl(tmp_table, tmp_schema, ddl, execute)
         if execute:
             self.default_db.execute(q)
 
@@ -55,23 +55,23 @@ class BaseSqlTask(Task):
             "Create Temp": lambda: self.create_select(
                 self.tmp_table, self.tmp_schema, self.sql_query, self.ddl
             ),
-            "Create Temp DDL": lambda: self.default_db.create_table_ddl(
+            "Create Temp DDL": lambda: self.default_db._create_table_ddl(
                 self.tmp_table, self.tmp_schema, self.ddl
             ),
-            "Create View": lambda: self.default_db.create_table_select(
+            "Create View": lambda: self.default_db._create_table_select(
                 self.table, self.schema, self.sql_query, view=True
             ),
-            "Create Indexes": lambda: self.default_db.create_indexes(
+            "Create Indexes": lambda: self.default_db._create_indexes(
                 self.tmp_table, self.tmp_schema, self.ddl
             ),
-            "Merge": lambda: self.default_db.merge_tables(
+            "Merge": lambda: self.default_db._merge_tables(
                 self.tmp_table,
                 self.tmp_schema,
                 self.table,
                 self.schema,
                 self.delete_key,
             ),
-            "Move": lambda: self.default_db.move_table(
+            "Move": lambda: self.default_db._move_table(
                 self.tmp_table, self.tmp_schema, self.table, self.schema, self.ddl,
             ),
             "Grant Permissions": lambda: self.default_db.grant_permissions(
@@ -147,17 +147,17 @@ class BaseSqlTask(Task):
 
         if len(ddl.get("columns")) == 0:
             out_sql.append(
-                self.default_db.create_table_select(
+                self.default_db._create_table_select(
                     table, schema, select, view=False, ddl=self.ddl
                 )
             )
         else:
             # create table with DDL and insert the output of the select
-            out_sql.append(self.default_db.create_table_ddl(table, schema, ddl))
+            out_sql.append(self.default_db._create_table_ddl(table, schema, ddl))
 
             ddl_column_names = [c["name"] for c in ddl.get("columns")]
             out_sql.append(
-                self.default_db.insert(table, schema, select, columns=ddl_column_names)
+                self.default_db._insert(table, schema, select, columns=ddl_column_names)
             )
 
         return "\n".join(out_sql)
@@ -171,14 +171,14 @@ class BaseSqlTask(Task):
 
         try:
             out_sql.append(
-                self.default_db.drop_table(table, schema, view=False, execute=execute)
+                self.default_db._drop_table(table, schema, view=False, execute=execute)
             )
         except:
             cleanup_table_failed = True
 
         try:
             out_sql.append(
-                self.default_db.drop_table(table, schema, view=True, execute=execute)
+                self.default_db._drop_table(table, schema, view=True, execute=execute)
             )
         except:
             cleanup_view_failed = True
@@ -221,7 +221,7 @@ class BaseSqlTask(Task):
 
         if not self.is_full_load and self.target_table_exists:
             if execute:
-                res = self.default_db.select(last_incremental_value_query)
+                res = self.default_db.read_data(last_incremental_value_query)
                 if len(res) == 1:
                     last_incremental_value = res[0]["value"]
             else:
@@ -239,7 +239,7 @@ class BaseSqlTask(Task):
             self.write_compilation_output(get_data_query, "get_data")
 
         if execute:
-            data_iter = source_db.select_stream(get_data_query)
+            data_iter = source_db._read_data_stream(get_data_query)
             return self.default_db.load_data(tmp_table, data_iter, schema=tmp_schema)
         else:
             return Ok()

--- a/sayn/tasks/copy.py
+++ b/sayn/tasks/copy.py
@@ -151,7 +151,7 @@ class CopyTask(BaseSqlTask):
 
     def get_columns(self):
         # We get the source table definition
-        source_table_def = self.source_db.get_table(
+        source_table_def = self.source_db._get_table(
             self.source_table,
             self.source_schema,
             # columns=[c["name"] for c in self.ddl["columns"]],
@@ -170,7 +170,7 @@ class CopyTask(BaseSqlTask):
         if len(self.ddl["columns"]) == 0:
             dst_table_def = None
             if not self.is_full_load:
-                dst_table_def = self.default_db.get_table(self.table, self.schema)
+                dst_table_def = self.default_db._get_table(self.table, self.schema)
 
             if dst_table_def is not None:
                 # In incremental loads we use the destination table to determine the columns

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -129,7 +129,7 @@ def simulate_task(type, sql_query=None, run_arguments=dict(), task_params=dict()
 
 
 def validate_table(db, table_name, expected_data):
-    result = db.select(f"select * from {table_name}")
+    result = db.read_data(f"select * from {table_name}")
     if len(result) != len(expected_data):
         return False
     for i in range(len(result)):

--- a/tests/test_task_autosql.py
+++ b/tests/test_task_autosql.py
@@ -220,63 +220,84 @@ def test_autosql_task_run_error(tmp_path):
         assert run_result.is_err
 
 
-# NEEDS FIXING DDL AUTOSQL BEHAVIOUR - SHOULD USE CREATE TEMP DDL WITH FULL COLUMN SPECS
-# def test_autosql_task_run_ddl_columns(tmp_path):
-#    with inside_dir(str(tmp_path)):
-#        task = simulate_task("autosql", sql_query=sql_query)
-#
-#        # setup
-#        setup_result = task.setup(
-#            file_name="test.sql",
-#            materialisation="table",
-#            destination={"table": "test_autosql_task"},
-#            ddl={"columns": [{"name": "x", "primary": True}]},
-#        )
-#        assert setup_result.is_ok
-#        assert task.steps == [
-#            "Write Query",
-#            "Cleanup",
-#            "Create Temp",
-#            "Cleanup Target",
-#            "Move",
-#        ]
-#
-#        # run
-#        run_result = task.run()
-#        assert run_result.is_ok
+def test_autosql_task_run_ddl_columns(tmp_path):
+    with inside_dir(str(tmp_path)):
+        task = simulate_task("autosql", sql_query=sql_query)
+
+        # setup
+        setup_result = task.setup(
+            file_name="test.sql",
+            materialisation="table",
+            destination={"table": "test_autosql_task"},
+            ddl={"columns": [{"name": "x", "primary": True}]},
+        )
+        assert setup_result.is_ok
+        assert task.steps == [
+            "Write Query",
+            "Cleanup",
+            "Create Temp",
+            "Cleanup Target",
+            "Move",
+        ]
+
+        # run
+        run_result = task.run()
+        assert run_result.is_ok
+        # test the pk has indeed been set
+        pk_info = task.default_db.read_data("PRAGMA table_info(test_autosql_task)")
+        assert pk_info[0]["pk"] == 1
 
 
-# def test_autosql_task_run_indexes_pk(tmp_path):
-#    # test indexes with the primary key
-#    # for SQLite this returns an error as primary keys can only be defined in the Create DDL statement
-#    with inside_dir(str(tmp_path)):
-#        task = simulate_task("autosql", sql_query=sql_query)
-#
-#        # setup
-#        setup_result = task.setup(
-#            file_name="test.sql",
-#            materialisation="table",
-#            destination={"table": "test_autosql_task"},
-#            ddl={"indexes": [{"primary_key": "x"}]},
-#        )
-#        if "PRIMARY KEY CREATE DDL ONLY" not in task.default_db.sql_features:
-#            assert setup_result.is_ok
-#            assert task.steps == [
-#                "Write Query",
-#                "Cleanup",
-#                "Create Temp",
-#                "Cleanup Target",
-#                "Move",
-#            ]
-#        else:
-#            assert setup_result.is_err
-#
-#        # run
-#        if "PRIMARY KEY CREATE DDL ONLY" not in task.default_db.sql_features:
-#            run_result = task.run()
-#            assert run_result.is_ok
+def test_autosql_task_run_indexes_pk(tmp_path):
+    # test indexes with the primary key only returns error on SQLite
+    # this is because SQLite requires primary keys to be defined in create table statement so columns definition is needed
+    with inside_dir(str(tmp_path)):
+        task = simulate_task("autosql", sql_query=sql_query)
 
-# add test pk defined differently in indexes and columns returns error
+        # setup
+        setup_result = task.setup(
+            file_name="test.sql",
+            materialisation="table",
+            destination={"table": "test_autosql_task"},
+            ddl={"indexes": [{"primary_key": "x"}]},
+        )
+        if "NO ALTER INDEXES" not in task.default_db.sql_features:
+            assert setup_result.is_ok
+            assert task.steps == [
+                "Write Query",
+                "Cleanup",
+                "Create Temp",
+                "Cleanup Target",
+                "Move",
+            ]
+        else:
+            assert setup_result.is_err
+
+        # run
+        if "NO ALTER INDEXES" not in task.default_db.sql_features:
+            run_result = task.run()
+            assert run_result.is_ok
+
+
+def test_autosql_task_ddl_diff_pk_err(tmp_path):
+    # test autosql task set with different pks in indexes and columns setup error
+    with inside_dir(tmp_path):
+        task = simulate_task("autosql", sql_query=sql_query_ddl_diff_col_order)
+
+        # setup
+        setup_result = task.setup(
+            file_name="test.sql",
+            materialisation="table",
+            destination={"table": "test_autosql_task"},
+            ddl={
+                "columns": [
+                    {"name": "x", "type": "text", "primary": True},
+                    {"name": "y", "type": "int"},
+                ],
+                "indexes": {"primary_key": {"columns": ["y"]}},
+            },
+        )
+        assert setup_result.is_err
 
 
 def test_autosql_task_run_ddl_diff_col_order(tmp_path):

--- a/tests/test_task_autosql.py
+++ b/tests/test_task_autosql.py
@@ -276,6 +276,8 @@ def test_autosql_task_run_error(tmp_path):
 #            run_result = task.run()
 #            assert run_result.is_ok
 
+# add test pk defined differently in indexes and columns returns error
+
 
 def test_autosql_task_run_ddl_diff_col_order(tmp_path):
     # test that autosql with ddl columns creates a table with order similar to ddl definition

--- a/tests/test_task_autosql.py
+++ b/tests/test_task_autosql.py
@@ -35,7 +35,7 @@ def test_autosql_task_table(tmp_path):
         assert validate_table(task.default_db, "test_autosql_task", [{"x": 1}],)
         assert (
             len(
-                task.default_db.select(
+                task.default_db.read_data(
                     'SELECT * FROM sqlite_master WHERE type="table" AND NAME = "test_autosql_task"'
                 )
             )
@@ -63,7 +63,7 @@ def test_autosql_task_view(tmp_path):
         assert validate_table(task.default_db, "test_autosql_task", [{"x": 1}],)
         assert (
             len(
-                task.default_db.select(
+                task.default_db.read_data(
                     'SELECT * FROM sqlite_master WHERE type="view" AND NAME = "test_autosql_task"'
                 )
             )


### PR DESCRIPTION
- Added primary_key attribute on the DDL object to store the primary_key at the first level if set (convenient for further access in code).
- For autosql, if columns are specified fully and a primary key is also defined. The primary_key will be set on the create table statement.
- For SQLite, added additional ddl check to force the specification of primary_key in columns if set. SQLite does not support ALTER statements for primary key.
- Amended the database API to limit what is surfaced to the user: execute, load_data, select (renamed to read_data) and grant_permissions