### PR TITLE
Add option to change DB destination

### DIFF
--- a/docs/tasks/autosql.md
+++ b/docs/tasks/autosql.md
@@ -29,10 +29,18 @@ An `autosql` task is defined by the following attributes:
 * `file_name`: the name of the file **within the sql folder of the project's root**.
 * `materialisation`: this should be either `table`, `view` or `incremental`. `table` will create a table, `view` will create a view. `incremental` will create a table and will load the data incrementally based on a delete key (see more detail on `incremental` below).
 * `destination`: this sets the details of the data processing.
-    * `tmp_schema`: specifies the schema which will be used to store any necessary temporary object created in the process. This is optional.
-    * `schema`: is the destination schema where the object will be created. This is optional.
+    * `tmp_schema`: the (optional) schema which will be used to store any necessary temporary object created in the process.
+    * `schema`: the (optional) destination schema where the object will be created.
     * `table`: is the name of the object that will be created.
+    * `db`: the (optional) destination database.
 * `delete_key`: specifies the incremental process delete key. This is for `incremental` `materialisation` only.
+
+!!! info
+    You do not need to specify `db` unless you want the destination database to be different than the `default_db` you define in `project.yaml` (which is the default database used by SAYN). If you define the `db` attribute, it needs to:
+
+      * Be a credential from the `required_credentials` list in `project.yaml`.
+      * Be defined in your `settings.yaml`.
+      * Be one of the supported [databases](../databases/overview.md).
 
 ## Using `autosql` In `incremental` Mode
 

--- a/docs/tasks/copy.md
+++ b/docs/tasks/copy.md
@@ -27,13 +27,21 @@ A `copy` task is defined as follows:
 
 * `type`: `copy`.
 * `source`: the source details
-    * `db`: a credential from the `required_credentials` list in `project.yaml` that's one of the supported [databases](../databases/overview.md).
+    * `db`: the source database.
     * `schema`: the (optional) source schema.
     * `table`: the name of the table top copy.
-* `destination`: the destination details. The destination database is the `default_db` set in `project.yaml`.
+* `destination`: the destination details.
     * `tmp_schema`: the (optional) staging schema used in the process of copying data.
     * `schema`: the (optional) destination schema.
     * `table`: the name of the table to store data into.
+    * `db`: the (optional) destination database.
+
+!!! info
+    You do not need to specify `db` unless you want the destination database to be different than the `default_db` you define in `project.yaml` (which is the default database used by SAYN). If you define the `db` attribute, it needs to:
+
+      * Be a credential from the `required_credentials` list in `project.yaml`.
+      * Be defined in your `settings.yaml`.
+      * Be one of the supported [databases](../databases/overview.md).
 
 By default, tables will be copied in full every time SAYN runs, but it can be changed into an incremental
 load by adding `incremental_key` and `delete_key`:

--- a/docs/tasks/sql.md
+++ b/docs/tasks/sql.md
@@ -16,5 +16,14 @@ A `sql` task is defined as follows:
       file_name: sql_task.sql
     ```
 
-Where `file_name` is the path to a file under the `sql` folder containing the
-SQL script to execute.
+A `sql` task is defined by the following attributes:
+
+* `file_name`: path to a file under the `sql` folder containing the SQL script to execute.
+* `db`: the (optional) destination database.
+
+!!! info
+    You do not need to specify `db` unless you want the destination database to be different than the `default_db` you define in `project.yaml` (which is the default database used by SAYN). If you define the `db` attribute, it needs to:
+
+      * Be a credential from the `required_credentials` list in `project.yaml`.
+      * Be defined in your `settings.yaml`.
+      * Be one of the supported [databases](../databases/overview.md).

--- a/sayn/tasks/__init__.py
+++ b/sayn/tasks/__init__.py
@@ -57,17 +57,13 @@ class Task:
         return {**self.project_parameters, **self.task_parameters}
 
     @property
-    def db(self):
+    def default_db(self):
         return self.connections[self._default_db]
 
     # Making it backwards compatible
     @property
     def logger(self):
         return self.tracker
-
-    @property
-    def default_db(self):
-        return self.connections[self._default_db]
 
     # Task lifetime methods
 

--- a/sayn/tasks/sql.py
+++ b/sayn/tasks/sql.py
@@ -1,14 +1,17 @@
 from pathlib import Path
 
 from pydantic import BaseModel, FilePath, validator
+from typing import Optional
 
-from ..core.errors import Ok
+from ..core.errors import Ok, Err
+from ..database import Database
 from .base_sql import BaseSqlTask
 
 
 class Config(BaseModel):
     sql_folder: Path
     file_name: FilePath
+    db: Optional[str]
 
     @validator("file_name", pre=True)
     def file_name_plus_folder(cls, v, values):
@@ -16,10 +19,20 @@ class Config(BaseModel):
 
 
 class SqlTask(BaseSqlTask):
-    def setup(self, file_name):
-        self.config = Config(
-            sql_folder=self.run_arguments["folders"]["sql"], file_name=file_name
-        )
+    def setup(self, **config):
+        conn_names_list = [
+            n for n, c in self.connections.items() if isinstance(c, Database)
+        ]
+
+        # set the target db for execution
+        if config.get("db") is not None:
+            if config["db"] not in conn_names_list:
+                return Err("task_definition", "db_not_in_settings", db=config["db"])
+            self._target_db = config["db"]
+        else:
+            self._target_db = self._default_db
+
+        self.config = Config(sql_folder=self.run_arguments["folders"]["sql"], **config)
 
         result = self.compile_obj(self.config.file_name)
         if result.is_err:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -100,19 +100,20 @@ def simulate_task(type, sql_query=None, run_arguments=dict(), task_params=dict()
     task.connections = {
         "target_db": create_db(
             "target_db", "target_db", {"type": "sqlite", "database": ":memory:"}
-        )
+        ),
+        "target_db2": create_db(
+            "target_db2", "target_db2", {"type": "sqlite", "database": ":memory:"}
+        ),
     }
 
-    task.connections.update(
-        {
-            "target_db2": create_db(
-                "target_db2", "target_db2", {"type": "sqlite", "database": ":memory:"}
-            ),
-            "source_db": create_db(
-                "source_db", "source_db", {"type": "sqlite", "database": ":memory:"}
-            ),
-        }
-    )
+    if type == "copy":
+        task.connections.update(
+            {
+                "source_db": create_db(
+                    "source_db", "source_db", {"type": "sqlite", "database": ":memory:"}
+                ),
+            }
+        )
 
     task._default_db = "target_db"
     task.tracker = vd

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -107,15 +107,10 @@ def simulate_task(type, sql_query=None, run_arguments=dict(), task_params=dict()
         {
             "target_db2": create_db(
                 "target_db2", "target_db2", {"type": "sqlite", "database": ":memory:"}
-            )
-        }
-    )
-
-    task.connections.update(
-        {
+            ),
             "source_db": create_db(
                 "source_db", "source_db", {"type": "sqlite", "database": ":memory:"}
-            )
+            ),
         }
     )
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -96,21 +96,30 @@ def simulate_task(type, sql_query=None, run_arguments=dict(), task_params=dict()
         "full_load": False,
         **run_arguments,
     }
+
     task.connections = {
-        "test_db": create_db(
-            "test_db", "test_db", {"type": "sqlite", "database": ":memory:"}
+        "target_db": create_db(
+            "target_db", "target_db", {"type": "sqlite", "database": ":memory:"}
         )
     }
-    if type == "copy":
-        task.connections.update(
-            {
-                "source_db": create_db(
-                    "source_db", "source_db", {"type": "sqlite", "database": ":memory:"}
-                )
-            }
-        )
 
-    task._default_db = "test_db"
+    task.connections.update(
+        {
+            "target_db2": create_db(
+                "target_db2", "target_db2", {"type": "sqlite", "database": ":memory:"}
+            )
+        }
+    )
+
+    task.connections.update(
+        {
+            "source_db": create_db(
+                "source_db", "source_db", {"type": "sqlite", "database": ":memory:"}
+            )
+        }
+    )
+
+    task._default_db = "target_db"
     task.tracker = vd
 
     task.jinja_env = Environment(


### PR DESCRIPTION
- Added the option to change the destination DB for sql, autosql and copy tasks.
- sql tasks uses a `db` attribute.
- autosql and copy tasks use a `db` attribute defined in `destination`.
- added unit tests to test set destination db for all tasks