### PR TITLE
Amend Python Task To Replace Logs Tables

### DIFF
--- a/sayn/scaffolding/data/init_project/python/load_data.py
+++ b/sayn/scaffolding/data/init_project/python/load_data.py
@@ -82,6 +82,6 @@ class LoadData(PythonTask):
         # Load logs
         for log_type, log_data in data_to_load.items():
             with self.step(f"Load {log_type}"):
-                self.default_db.load_data(f"logs_{log_type}", log_data)
+                self.default_db.load_data(f"logs_{log_type}", log_data, replace=True)
 
         return self.success()


### PR DESCRIPTION
- Added replace=True on the load_data function to prevent logs duplication