### PR TITLE
Fixes to step counter in task tracker

### DIFF
--- a/sayn/logging/fancy_logger.py
+++ b/sayn/logging/fancy_logger.py
@@ -113,6 +113,7 @@ class FancyLogger(Logger):
                 self.app_stage_start(stage, details)
 
             elif event == "finish_stage":
+                self.spinner.stop()
                 print()
                 self.stage = None
                 self.app_stage_finish(stage, details)

--- a/sayn/logging/task_event_tracker.py
+++ b/sayn/logging/task_event_tracker.py
@@ -7,7 +7,7 @@ class TaskEventTracker:
     _logger = None
     _task_name = None
     _task_order = None
-    _steps = list()
+    _steps = None
     _current_step = None
     _current_step_start_ts = None
 
@@ -15,6 +15,7 @@ class TaskEventTracker:
         self._logger = logger
         self._task_name = task_name
         self._task_order = task_order
+        self._steps = list()
 
     def _report_event(self, event, **details):
         details["event"] = event
@@ -37,8 +38,15 @@ class TaskEventTracker:
         self._report_event("set_run_steps", steps=steps)
         self._steps = steps
 
+    def add_run_steps(self, steps):
+        self._report_event("set_run_steps", steps=steps)
+        self._steps.extend(steps)
+
     def start_step(self, step):
         self.finish_current_step()
+
+        if step not in self._steps:
+            self._steps.append(step)
 
         self._current_step = step
         self._current_step_start_ts = datetime.now()

--- a/sayn/tasks/__init__.py
+++ b/sayn/tasks/__init__.py
@@ -102,6 +102,10 @@ class Task:
         """Sets the run steps for the task, allowing the CLI to indicate task execution progress. """
         self.tracker.set_run_steps(steps)
 
+    def add_run_steps(self, steps):
+        """Adds new steps to the list of run steps for the task, allowing the CLI to indicate task execution progress. """
+        self.tracker.add_run_steps(steps)
+
     def start_step(self, step):
         """Specifies the start of a task step"""
         self.tracker.start_step(step)


### PR DESCRIPTION
## This PR:

- Fixes step counting when `self.set_run_steps` is not called in Python tasks
- Introduces `self.add_run_steps` that appends steps to the task list. Useful when the steps are not known at the start of the run
- Fixes an issue with the spinner that wasn't removing the last task from the screen in the setup section