### PR TITLE
Issue Fixed

### DIFF
--- a/sayn/tasks/autosql.py
+++ b/sayn/tasks/autosql.py
@@ -43,8 +43,6 @@ class Config(BaseModel):
     destination: Destination
     ddl: Optional[Dict[str, Any]]
 
-    # need to define a pydantic Config class
-    # to avoid voodoo magic shenanigans
     class Config:
         extra = Extra.forbid
 

--- a/sayn/tasks/copy.py
+++ b/sayn/tasks/copy.py
@@ -63,8 +63,6 @@ class Config(BaseModel):
     max_merge_rows: Optional[int]
     max_batch_rows: Optional[int]
 
-    # need to define a pydantic Config class
-    # to avoid voodoo magic shenanigans
     class Config:
         extra = Extra.forbid
 

--- a/sayn/tasks/sql.py
+++ b/sayn/tasks/sql.py
@@ -13,8 +13,6 @@ class Config(BaseModel):
     file_name: FilePath
     db: Optional[str]
 
-    # need to define a pydantic Config class
-    # to avoid voodoo magic shenanigans
     class Config:
         extra = Extra.forbid
 


### PR DESCRIPTION
Fixed the issue by adding extra=Extra.forbid in the Config definitions. That way if an invalid attribute gets defined, sayn will fail. Might need to improve error outputs for better user experience.