### PR TITLE
Performance improvement for Test Outputs

### DIFF
--- a/sayn/tasks/autosql.py
+++ b/sayn/tasks/autosql.py
@@ -254,7 +254,8 @@ class AutoSqlTask(SqlTask):
                 if len(result) == 0:
                     return self.success()
                 else:
-                    errout = "Test failed, summary:\n"
+                    errout = "Test failed, summary:\n\n"
+                    errout += f"Total number of offending records: {sum([item['cnt'] for item in result])} \n"
                     data = []
                     data.append(
                         ["Breach Count", "Prob. Value", "Test Type", "Failed Fields"]
@@ -264,4 +265,6 @@ class AutoSqlTask(SqlTask):
                         data.append([res["cnt"], res["val"], res["type"], res["col"]])
                     table = AsciiTable(data)
 
-                    return self.fail(errout + table.table)
+                    errinfo = f"You can find the compiled test query at compile/{self.group}/{self.name}_test.sql"
+
+                    return self.fail(errout + table.table + "\n\n" + errinfo)

--- a/sayn/tasks/copy.py
+++ b/sayn/tasks/copy.py
@@ -285,7 +285,8 @@ class CopyTask(SqlTask):
                 if len(result) == 0:
                     return self.success()
                 else:
-                    errout = "Test failed, summary:\n"
+                    errout = "Test failed, summary:\n\n"
+                    errout += f"Total number of offending records: {sum([item['cnt'] for item in result])} \n"
                     data = []
                     data.append(
                         ["Breach Count", "Prob. Value", "Test Type", "Failed Fields"]
@@ -295,7 +296,9 @@ class CopyTask(SqlTask):
                         data.append([res["cnt"], res["val"], res["type"], res["col"]])
                     table = AsciiTable(data)
 
-                    return self.fail(errout + table.table)
+                    errinfo = f"You can find the compiled test query at compile/{self.group}/{self.name}_test.sql"
+
+                    return self.fail(errout + table.table + "\n\n" + errinfo)
 
     def execute(self, execute, debug, is_full_load, limit=None):
         # Introspect target

--- a/sayn/tasks/test.py
+++ b/sayn/tasks/test.py
@@ -65,6 +65,7 @@ class TestTask(Task):
             return result
         else:
             self.test_query = result.value
+            self.test_query += "LIMIT 5\n"
 
         if self.run_arguments["command"] == "test":
             self.set_run_steps(["Write Query", "Execute Query"])

--- a/sayn/tasks/test.py
+++ b/sayn/tasks/test.py
@@ -65,7 +65,7 @@ class TestTask(Task):
             return result
         else:
             self.test_query = result.value
-            self.test_query += "LIMIT 5\n"
+            self.test_query += " LIMIT 5\n"
 
         if self.run_arguments["command"] == "test":
             self.set_run_steps(["Write Query", "Execute Query"])

--- a/sayn/tasks/test.py
+++ b/sayn/tasks/test.py
@@ -91,4 +91,6 @@ class TestTask(Task):
                     data.append(list(res.values()))
                 table = AsciiTable(data)
 
-                return self.fail(errout + table.table)
+                errinfo = f"You can find the compiled test query at compile/{self.group}/{self.name}_test.sql"
+
+                return self.fail(errout + table.table + "\n\n" + errinfo)

--- a/sayn/tasks/tests/standard_tests.sql
+++ b/sayn/tasks/tests/standard_tests.sql
@@ -13,6 +13,7 @@ FROM (SELECT CAST(l.{{ name }} AS VARCHAR) AS val
 {%- endif %}
  GROUP BY l.{{ name }}
 HAVING COUNT(*) > {%- if type == 'unique' %} 1 {%- else %} 0 {%- endif %}
+ORDER BY cnt DESC
 LIMIT 5) AS t
 
 UNION ALL

--- a/sayn/tasks/tests/standard_tests.sql
+++ b/sayn/tasks/tests/standard_tests.sql
@@ -1,6 +1,7 @@
 {% set dst_schema = schema+'.' if schema else '' %}
 
-(SELECT CAST(l.{{ name }} AS VARCHAR) AS val
+SELECT  *
+FROM (SELECT CAST(l.{{ name }} AS VARCHAR) AS val
      , COUNT(*) AS cnt
      , '{{ type }}' AS type
      , '{{ name }}' AS col
@@ -12,6 +13,6 @@
 {%- endif %}
  GROUP BY l.{{ name }}
 HAVING COUNT(*) > {%- if type == 'unique' %} 1 {%- else %} 0 {%- endif %}
-LIMIT 5)
+LIMIT 5) AS t
 
 UNION ALL

--- a/sayn/tasks/tests/standard_tests.sql
+++ b/sayn/tasks/tests/standard_tests.sql
@@ -1,6 +1,6 @@
 {% set dst_schema = schema+'.' if schema else '' %}
 
-SELECT CAST(l.{{ name }} AS VARCHAR) AS val
+(SELECT CAST(l.{{ name }} AS VARCHAR) AS val
      , COUNT(*) AS cnt
      , '{{ type }}' AS type
      , '{{ name }}' AS col
@@ -12,5 +12,6 @@ SELECT CAST(l.{{ name }} AS VARCHAR) AS val
 {%- endif %}
  GROUP BY l.{{ name }}
 HAVING COUNT(*) > {%- if type == 'unique' %} 1 {%- else %} 0 {%- endif %}
+LIMIT 5)
 
 UNION ALL

--- a/sayn/tasks/tests/standard_tests.sql
+++ b/sayn/tasks/tests/standard_tests.sql
@@ -13,7 +13,6 @@ FROM (SELECT CAST(l.{{ name }} AS VARCHAR) AS val
 {%- endif %}
  GROUP BY l.{{ name }}
 HAVING COUNT(*) > {%- if type == 'unique' %} 1 {%- else %} 0 {%- endif %}
-ORDER BY cnt DESC
 LIMIT 5) AS t
 
 UNION ALL

--- a/sayn/tasks/tests/standard_tests_bigquery.sql
+++ b/sayn/tasks/tests/standard_tests_bigquery.sql
@@ -11,6 +11,7 @@
  WHERE l.{{ name }} NOT IN ( {{ values }} )
 {%- endif %}
  GROUP BY l.{{ name }}
-HAVING COUNT(*) > {%- if type == 'unique' %} 1 {%- else %} 0 {%- endif %})
+HAVING COUNT(*) > {%- if type == 'unique' %} 1 {%- else %} 0 {%- endif %}
+LIMIT 5)
 
 UNION ALL

--- a/sayn/tasks/tests/standard_tests_bigquery.sql
+++ b/sayn/tasks/tests/standard_tests_bigquery.sql
@@ -12,7 +12,6 @@
 {%- endif %}
  GROUP BY l.{{ name }}
 HAVING COUNT(*) > {%- if type == 'unique' %} 1 {%- else %} 0 {%- endif %}
-ORDER BY cnt DESC
 LIMIT 5)
 
 UNION ALL

--- a/sayn/tasks/tests/standard_tests_bigquery.sql
+++ b/sayn/tasks/tests/standard_tests_bigquery.sql
@@ -12,6 +12,7 @@
 {%- endif %}
  GROUP BY l.{{ name }}
 HAVING COUNT(*) > {%- if type == 'unique' %} 1 {%- else %} 0 {%- endif %}
+ORDER BY cnt DESC
 LIMIT 5)
 
 UNION ALL


### PR DESCRIPTION
Added a `LIMIT` to the standard and custom test queries.
`LIMIT` is set to 5 per field per test type.