### PR TITLE
Fix SQL Macro Jinja Compilation error

### DIFF
--- a/sayn/utils/compiler.py
+++ b/sayn/utils/compiler.py
@@ -49,6 +49,7 @@ class Compiler(BaseCompiler):
             loader=FileSystemLoader(Path(".")),
             undefined=StrictUndefined,
             keep_trailing_newline=True,
+            cache_size=0,
         )
 
     def _get_template(


### PR DESCRIPTION
Applied cache_size=0 in Environment compiler to force recompilation of sql macros.