### PR TITLE
BugFix: A Full Load would trigger a Replace Table Statement for SQL Script Tasks

### DIFF
--- a/sayn/tasks/sql.py
+++ b/sayn/tasks/sql.py
@@ -345,7 +345,7 @@ class SqlTask(Task):
                 **self.ddl,
             )
 
-        elif self.materialisation == "table" or self.run_arguments["full_load"]:
+        elif self.materialisation == "table":
             # Full load or target table missing
             if self.target_db.feature("CANNOT CHANGE SCHEMA"):
                 # Use destination schema if the db doesn't support schema changes


### PR DESCRIPTION
Removed condition that replaces table when on Full Load.