### PR TITLE
Bugfix: Test applied on Target DB

### DIFF
--- a/sayn/tasks/autosql.py
+++ b/sayn/tasks/autosql.py
@@ -396,7 +396,7 @@ class AutoSqlTask(SqlTask):
                         self.write_compilation_output(query, "test")
                     if "Execute" in step:
                         try:
-                            result = self.default_db.read_data(query)
+                            result = self.target_db.read_data(query)
                         except Exception as e:
                             return Exc(e)
 
@@ -406,7 +406,7 @@ class AutoSqlTask(SqlTask):
                 errout, failed = self.test_failure(
                     breakdown, result, self.run_arguments["debug"]
                 )
-                problematic_values_query = self.default_db.test_problematic_values(
+                problematic_values_query = self.target_db.test_problematic_values(
                     failed, self.table, self.schema
                 )
 

--- a/sayn/tasks/copy.py
+++ b/sayn/tasks/copy.py
@@ -382,7 +382,7 @@ class CopyTask(SqlTask):
                         self.write_compilation_output(query, "test")
                     if "Execute" in step:
                         try:
-                            result = self.default_db.read_data(query)
+                            result = self.target_db.read_data(query)
                         except Exception as e:
                             return Exc(e)
 
@@ -392,7 +392,7 @@ class CopyTask(SqlTask):
                 errout, failed = self.test_failure(
                     breakdown, result, self.run_arguments["debug"]
                 )
-                problematic_values_query = self.default_db.test_problematic_values(
+                problematic_values_query = self.target_db.test_problematic_values(
                     failed, self.table, self.schema
                 )
 

--- a/sayn/tasks/sql.py
+++ b/sayn/tasks/sql.py
@@ -463,7 +463,7 @@ class SqlTask(Task):
                         self.write_compilation_output(query, "test")
                     if "Execute" in step:
                         try:
-                            result = self.default_db.read_data(query)
+                            result = self.target_db.read_data(query)
                         except Exception as e:
                             return Exc(e)
 
@@ -473,7 +473,7 @@ class SqlTask(Task):
                 errout, failed = self.test_failure(
                     breakdown, result, self.run_arguments["debug"]
                 )
-                problematic_values_query = self.default_db.test_problematic_values(
+                problematic_values_query = self.target_db.test_problematic_values(
                     failed, self.table, self.schema
                 )
 

--- a/sayn/tasks/test.py
+++ b/sayn/tasks/test.py
@@ -31,6 +31,8 @@ class Config(BaseModel):
     test_folder: Path
     file_name: FilePath
 
+    db: Optional[str]
+
     class Config:
         extra = Extra.forbid
 
@@ -46,6 +48,7 @@ class OnFailValue(str, Enum):
 
 class CompileConfig(BaseModel):
     tags: Optional[List[str]]
+    db: Optional[str]  # need to make a BaseConfig class instead
     # sources: Optional[List[str]]
     # outputs: Optional[List[str]]
     # parents: Optional[List[str]]
@@ -82,6 +85,8 @@ class TestTask(Task):
         except Exception as e:
             return Exc(e)
 
+        self.allow_config = True
+
         self.compiler.update_globals(
             src=lambda x: self.src(x, connection=self._target_db),
             config=self.config_macro,
@@ -89,6 +94,8 @@ class TestTask(Task):
 
         self.test_query = self.compiler.compile(self.task_config.file_name)
         self.test_query += " LIMIT 5\n"
+
+        self.allow_config = False
 
         return Ok()
 
@@ -102,6 +109,23 @@ class TestTask(Task):
 
             if task_config_override.tags is not None:
                 self._config_input["tags"] = task_config_override.tags
+
+            self.task_config.db = (
+                task_config_override.db or self.task_config.db or self._default_db
+            )
+
+            conn_names_list = [
+                n for n, c in self.connections.items() if isinstance(c, Database)
+            ]
+
+            if self.task_config.db not in conn_names_list:
+                return Err(
+                    "task_definition",
+                    "destination_db_not_in_settings",
+                    db=config["db"],
+                )
+            else:
+                self._target_db = self.task_config.db
 
             # if task_config_override.parents is not None:
             #     self._config_input["parents"] = task_config_override.parents

--- a/sayn/tasks/test.py
+++ b/sayn/tasks/test.py
@@ -56,6 +56,10 @@ class CompileConfig(BaseModel):
 
 
 class TestTask(Task):
+    @property
+    def target_db(self):
+        return self.connections[self._target_db]
+
     def config(self, **config):
         self._has_tests = True
 
@@ -125,7 +129,7 @@ class TestTask(Task):
                     self.write_compilation_output(query, "test")
                 if "Execute" in step:
                     try:
-                        result = self.default_db.read_data(query)
+                        result = self.target_db.read_data(query)
                     except Exception as e:
                         return Exc(e)
 
@@ -133,7 +137,6 @@ class TestTask(Task):
             return self.success()
         else:
             if self.run_arguments["debug"]:
-
                 errinfo = f"Test failed. You can find the compiled test query at compile/{self.group}/{self.name}_test.sql"
 
                 return self.fail(errinfo)


### PR DESCRIPTION
Amend SAYN tasks Tests to operate on the `target_db` instead of `default_db`. 