### PR TITLE
Feat: Interrupt Flag

### DIFF
--- a/sayn/cli.py
+++ b/sayn/cli.py
@@ -17,6 +17,7 @@ class CliApp(App):
         self,
         command,
         debug=False,
+        interrupt=False,
         include=None,
         exclude=None,
         upstream_prod=False,
@@ -68,6 +69,9 @@ class CliApp(App):
         if upstream_prod is not None:
             self.run_arguments.upstream_prod = upstream_prod
 
+        if interrupt is not None:
+            self.run_arguments.interrupt = interrupt
+
         self.start_app()
 
 
@@ -115,6 +119,14 @@ class ChainOption(click.Option):
 
 click_debug = click.option(
     "--debug", "-d", is_flag=True, default=False, help="Include debug messages"
+)
+
+click_interrupt = click.option(
+    "--interrupt",
+    "-i",
+    is_flag=True,
+    default=False,
+    help="Interrupt execution on first failure.",
 )
 
 
@@ -168,6 +180,7 @@ def click_incremental(func):
 
 def click_run_options(func):
     func = click_debug(func)
+    func = click_interrupt(func)
     func = click.option("--profile", "-p", help="Profile from settings to use")(func)
     func = click_incremental(func)
     func = click_filter(func)
@@ -190,13 +203,24 @@ def init(sayn_project_name):
 
 @cli.command(help="Compile sql tasks.")
 @click_run_options
-def compile(debug, tasks, exclude, upstream_prod, profile, full_load, start_dt, end_dt):
+def compile(
+    debug,
+    interrupt,
+    tasks,
+    exclude,
+    upstream_prod,
+    profile,
+    full_load,
+    start_dt,
+    end_dt,
+):
 
     tasks = [i for t in tasks for i in t.strip().split(" ")]
     exclude = [i for t in exclude for i in t.strip().split(" ")]
     app = CliApp(
         Command.COMPILE,
         debug,
+        interrupt,
         tasks,
         exclude,
         upstream_prod,
@@ -215,13 +239,24 @@ def compile(debug, tasks, exclude, upstream_prod, profile, full_load, start_dt, 
 
 @cli.command(help="Run SAYN tasks.")
 @click_run_options
-def run(debug, tasks, exclude, upstream_prod, profile, full_load, start_dt, end_dt):
+def run(
+    debug,
+    interrupt,
+    tasks,
+    exclude,
+    upstream_prod,
+    profile,
+    full_load,
+    start_dt,
+    end_dt,
+):
 
     tasks = [i for t in tasks for i in t.strip().split(" ")]
     exclude = [i for t in exclude for i in t.strip().split(" ")]
     app = CliApp(
         Command.RUN,
         debug,
+        interrupt,
         tasks,
         exclude,
         upstream_prod,
@@ -240,13 +275,24 @@ def run(debug, tasks, exclude, upstream_prod, profile, full_load, start_dt, end_
 
 @cli.command(help="Test SAYN tasks.")
 @click_run_options
-def test(debug, tasks, exclude, upstream_prod, profile, full_load, start_dt, end_dt):
+def test(
+    debug,
+    interrupt,
+    tasks,
+    exclude,
+    upstream_prod,
+    profile,
+    full_load,
+    start_dt,
+    end_dt,
+):
 
     tasks = [i for t in tasks for i in t.strip().split(" ")]
     exclude = [i for t in exclude for i in t.strip().split(" ")]
     app = CliApp(
         Command.TEST,
         debug,
+        interrupt,
         tasks,
         exclude,
         upstream_prod,

--- a/sayn/cli.py
+++ b/sayn/cli.py
@@ -122,11 +122,10 @@ click_debug = click.option(
 )
 
 click_interrupt = click.option(
-    "--interrupt",
-    "-i",
+    "--fail-fast",
     is_flag=True,
     default=False,
-    help="Interrupt execution on first failure.",
+    help="Interrupt remaining task execution on first failure.",
 )
 
 

--- a/sayn/cli.py
+++ b/sayn/cli.py
@@ -17,7 +17,6 @@ class CliApp(App):
         self,
         command,
         debug=False,
-        interrupt=False,
         include=None,
         exclude=None,
         upstream_prod=False,
@@ -25,6 +24,7 @@ class CliApp(App):
         full_load=False,
         start_dt=None,
         end_dt=None,
+        fail_fast=False,
     ):
         super().__init__()
 
@@ -69,8 +69,8 @@ class CliApp(App):
         if upstream_prod is not None:
             self.run_arguments.upstream_prod = upstream_prod
 
-        if interrupt is not None:
-            self.run_arguments.interrupt = interrupt
+        if fail_fast is not None:
+            self.run_arguments.fail_fast = fail_fast
 
         self.start_app()
 
@@ -121,7 +121,7 @@ click_debug = click.option(
     "--debug", "-d", is_flag=True, default=False, help="Include debug messages"
 )
 
-click_interrupt = click.option(
+click_fail_fast = click.option(
     "--fail-fast",
     is_flag=True,
     default=False,
@@ -179,7 +179,7 @@ def click_incremental(func):
 
 def click_run_options(func):
     func = click_debug(func)
-    func = click_interrupt(func)
+    func = click_fail_fast(func)
     func = click.option("--profile", "-p", help="Profile from settings to use")(func)
     func = click_incremental(func)
     func = click_filter(func)
@@ -204,7 +204,6 @@ def init(sayn_project_name):
 @click_run_options
 def compile(
     debug,
-    interrupt,
     tasks,
     exclude,
     upstream_prod,
@@ -212,6 +211,7 @@ def compile(
     full_load,
     start_dt,
     end_dt,
+    fail_fast,
 ):
 
     tasks = [i for t in tasks for i in t.strip().split(" ")]
@@ -219,7 +219,6 @@ def compile(
     app = CliApp(
         Command.COMPILE,
         debug,
-        interrupt,
         tasks,
         exclude,
         upstream_prod,
@@ -227,6 +226,7 @@ def compile(
         full_load,
         start_dt,
         end_dt,
+        fail_fast,
     )
 
     app.compile()
@@ -240,7 +240,6 @@ def compile(
 @click_run_options
 def run(
     debug,
-    interrupt,
     tasks,
     exclude,
     upstream_prod,
@@ -248,6 +247,7 @@ def run(
     full_load,
     start_dt,
     end_dt,
+    fail_fast,
 ):
 
     tasks = [i for t in tasks for i in t.strip().split(" ")]
@@ -255,7 +255,6 @@ def run(
     app = CliApp(
         Command.RUN,
         debug,
-        interrupt,
         tasks,
         exclude,
         upstream_prod,
@@ -263,6 +262,7 @@ def run(
         full_load,
         start_dt,
         end_dt,
+        fail_fast,
     )
 
     app.run()
@@ -276,7 +276,6 @@ def run(
 @click_run_options
 def test(
     debug,
-    interrupt,
     tasks,
     exclude,
     upstream_prod,
@@ -284,6 +283,7 @@ def test(
     full_load,
     start_dt,
     end_dt,
+    fail_fast,
 ):
 
     tasks = [i for t in tasks for i in t.strip().split(" ")]
@@ -291,7 +291,6 @@ def test(
     app = CliApp(
         Command.TEST,
         debug,
-        interrupt,
         tasks,
         exclude,
         upstream_prod,
@@ -299,6 +298,7 @@ def test(
         full_load,
         start_dt,
         end_dt,
+        fail_fast,
     )
 
     app.test()

--- a/sayn/core/app.py
+++ b/sayn/core/app.py
@@ -612,10 +612,14 @@ class App:
         self.tracker.start_stage(
             self.run_arguments.command.value, tasks=list(tasks_in_query.keys())
         )
+        interrupt_flag = False
 
         for task in self.tasks.values():
             if not task.in_query:
                 continue
+
+            if interrupt_flag:
+                task.is_interrupted = True
 
             # We force the run/compile so that the skipped status can be calculated,
             # but we only report if the task is in the query
@@ -638,7 +642,7 @@ class App:
                 )
 
             if self.run_arguments.interrupt and result.is_err:
-                self.check_abort(result)
+                interrupt_flag = True
 
         self.tracker.finish_current_stage(
             tasks={k: v.status for k, v in tasks_in_query.items()},

--- a/sayn/core/app.py
+++ b/sayn/core/app.py
@@ -68,7 +68,7 @@ class RunArguments:
     command: Command = Command.UNDEFINED
     upstream_prod: bool = False
     is_prod: bool = False
-    interrupt: bool = False
+    fail_fast: bool = False
 
     include: Set[str]
     exclude: Set[str]
@@ -617,7 +617,7 @@ class App:
                 continue
 
             if interrupt_flag:
-                task.is_interrupted = True
+                task.fail_fast = True
 
             # We force the run/compile so that the skipped status can be calculated,
             # but we only report if the task is in the query
@@ -639,7 +639,7 @@ class App:
                     "finish_stage", duration=datetime.now() - start_ts, result=result
                 )
 
-            if self.run_arguments.interrupt and result.is_err:
+            if self.run_arguments.fail_fast and result.is_err:
                 interrupt_flag = True
 
         self.tracker.finish_current_stage(
@@ -651,7 +651,7 @@ class App:
 
     def finish_app(self, error=None):
         duration = datetime.now() - self.app_start_ts
-        if self.run_arguments.interrupt and error is not None:
+        if self.run_arguments.fail_fast and error is not None:
             self.tracker.report_event(
                 event="finish_stage",
                 duration=duration,

--- a/sayn/core/app.py
+++ b/sayn/core/app.py
@@ -590,8 +590,6 @@ class App:
         """
         if result is None or not isinstance(result, Result):
             self.finish_app(error=Err("app_setup", "unhandled_error", result=result))
-        elif result.is_err and self.run_arguments.interrupt:
-            self.finish_app(result)
         elif result.is_err:
             self.finish_app(result)
         else:

--- a/sayn/core/app.py
+++ b/sayn/core/app.py
@@ -653,7 +653,12 @@ class App:
             self.tracker.report_event(
                 event="finish_stage",
                 duration=duration,
-                tasks={k: v.status for k, v in self.tasks.items()},
+                tasks={
+                    k: v.status
+                    if v.status in (TaskStatus.SUCCEEDED, TaskStatus.FAILED)
+                    else TaskStatus.SKIPPED
+                    for k, v in self.tasks.items()
+                },
             )
             sys.exit(-1)
         elif error is not None:

--- a/sayn/logging/fancy_logger.py
+++ b/sayn/logging/fancy_logger.py
@@ -52,6 +52,9 @@ class FancyLogger(Logger):
             if result.error.code == "parent_errors":
                 self.spinner.text_color = "yellow"
                 self.spinner.warn()
+            if result.error.code == "interrupted":
+                self.spinner.text_color = "yellow"
+                self.spinner.warn()
             elif (
                 result.error.code == "setup_error"
                 and result.error.details["status"].value == "skipped"

--- a/sayn/logging/log_formatter.py
+++ b/sayn/logging/log_formatter.py
@@ -286,6 +286,10 @@ class LogFormatter:
                 f"Skipping due to ancestors errors: {parents} ({duration})"
             )
 
+        elif error.code == "interrupted":
+            level = "warning"
+            message = self.warn(f"Skipping due to Interrupt signal ({duration})")
+
         elif error.code == "setup_error":
             if error.details["status"].value == "skipped":
                 level = "warning"

--- a/sayn/tasks/task_wrapper.py
+++ b/sayn/tasks/task_wrapper.py
@@ -88,7 +88,7 @@ class TaskWrapper:
         self.used_connections = set()
         self.tracker = tracker
         self.runner = None
-        self.is_interrupted = False
+        self.fail_fast = False
 
         self.name = name
         self.group = group
@@ -267,7 +267,7 @@ class TaskWrapper:
         self.compiler.update_globals(**task_parameters)
 
     def check_skip(self):
-        if self.is_interrupted:
+        if self.fail_fast:
             self.status = TaskStatus.SKIPPED
             return Err("task", "interrupted")
 

--- a/sayn/tasks/task_wrapper.py
+++ b/sayn/tasks/task_wrapper.py
@@ -88,6 +88,7 @@ class TaskWrapper:
         self.used_connections = set()
         self.tracker = tracker
         self.runner = None
+        self.is_interrupted = False
 
         self.name = name
         self.group = group
@@ -266,6 +267,10 @@ class TaskWrapper:
         self.compiler.update_globals(**task_parameters)
 
     def check_skip(self):
+        if self.is_interrupted:
+            self.status = TaskStatus.SKIPPED
+            return Err("task", "interrupted")
+
         if self.run_arguments["command"] != "test":
             failed_parents = {
                 p.name: p.status

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,17 @@ def cli():
 
 @cli.command()
 @tcli.click_run_options
-def run(debug, tasks, exclude, upstream_prod, profile, full_load, start_dt, end_dt):
+def run(
+    debug,
+    interrupt,
+    tasks,
+    exclude,
+    upstream_prod,
+    profile,
+    full_load,
+    start_dt,
+    end_dt,
+):
 
     tasks = [i for t in tasks for i in t.strip().split(" ")]
     exclude = [i for t in exclude for i in t.strip().split(" ")]
@@ -29,6 +39,7 @@ def run(debug, tasks, exclude, upstream_prod, profile, full_load, start_dt, end_
     return {
         "command": "run",
         "debug": debug,
+        "interrupt": interrupt,
         "include": tasks,
         "exclude": exclude,
         "profile": profile,
@@ -40,7 +51,17 @@ def run(debug, tasks, exclude, upstream_prod, profile, full_load, start_dt, end_
 
 @cli.command()
 @tcli.click_run_options
-def compile(debug, tasks, exclude, upstream_prod, profile, full_load, start_dt, end_dt):
+def compile(
+    debug,
+    interrupt,
+    tasks,
+    exclude,
+    upstream_prod,
+    profile,
+    full_load,
+    start_dt,
+    end_dt,
+):
 
     tasks = [i for t in tasks for i in t.strip().split(" ")]
     exclude = [i for t in exclude for i in t.strip().split(" ")]
@@ -53,6 +74,7 @@ def compile(debug, tasks, exclude, upstream_prod, profile, full_load, start_dt, 
     return {
         "command": "compile",
         "debug": debug,
+        "interrupt": interrupt,
         "include": tasks,
         "exclude": exclude,
         "profile": profile,
@@ -75,6 +97,7 @@ def test_simple_run():
     assert output == {
         "command": "run",
         "debug": False,
+        "interrupt": False,
         "include": [],
         "exclude": [],
         "profile": None,
@@ -90,6 +113,7 @@ def test_simple_compile():
     assert output == {
         "command": "compile",
         "debug": False,
+        "interrupt": False,
         "include": [],
         "exclude": [],
         "profile": None,
@@ -105,6 +129,7 @@ def test_run_one_task():
     assert output == {
         "command": "run",
         "debug": False,
+        "interrupt": False,
         "include": ["something"],
         "exclude": [],
         "profile": None,
@@ -120,6 +145,7 @@ def test_run_two_tasks_old():
     assert output == {
         "command": "run",
         "debug": False,
+        "interrupt": False,
         "include": ["something", "somethingelse"],
         "exclude": [],
         "profile": None,
@@ -135,6 +161,7 @@ def test_run_two_tasks_new():
     assert output == {
         "command": "run",
         "debug": False,
+        "interrupt": False,
         "include": ["something", "somethingelse"],
         "exclude": [],
         "profile": None,
@@ -150,6 +177,7 @@ def test_compile_one_task():
     assert output == {
         "command": "compile",
         "debug": False,
+        "interrupt": False,
         "include": ["something"],
         "exclude": [],
         "profile": None,
@@ -165,6 +193,7 @@ def test_compile_two_tasks_old():
     assert output == {
         "command": "compile",
         "debug": False,
+        "interrupt": False,
         "include": ["something", "somethingelse"],
         "exclude": [],
         "profile": None,
@@ -180,6 +209,7 @@ def test_compile_two_tasks_new():
     assert output == {
         "command": "compile",
         "debug": False,
+        "interrupt": False,
         "include": ["something", "somethingelse"],
         "exclude": [],
         "profile": None,
@@ -195,6 +225,7 @@ def test_run_debug():
     assert output == {
         "command": "run",
         "debug": True,
+        "interrupt": False,
         "include": ["something"],
         "exclude": [],
         "profile": None,
@@ -210,6 +241,7 @@ def test_compile_debug():
     assert output == {
         "command": "compile",
         "debug": True,
+        "interrupt": False,
         "include": ["something"],
         "exclude": [],
         "profile": None,
@@ -225,6 +257,7 @@ def test_run_debug_multitasks():
     assert output == {
         "command": "run",
         "debug": True,
+        "interrupt": False,
         "include": ["something", "somethingelse", "somesomeelse"],
         "exclude": [],
         "profile": None,
@@ -240,6 +273,71 @@ def test_compile_debug_multitasks():
     assert output == {
         "command": "compile",
         "debug": True,
+        "interrupt": False,
+        "include": ["something", "somethingelse", "somesomeelse"],
+        "exclude": [],
+        "profile": None,
+        "full_load": False,
+        "start_dt": None,
+        "end_dt": None,
+    }
+
+
+def test_run_interrupt():
+    output = get_output("run -t something -i")
+
+    assert output == {
+        "command": "run",
+        "debug": False,
+        "interrupt": True,
+        "include": ["something"],
+        "exclude": [],
+        "profile": None,
+        "full_load": False,
+        "start_dt": None,
+        "end_dt": None,
+    }
+
+
+def test_compile_interrupt():
+    output = get_output("compile -t something -i")
+
+    assert output == {
+        "command": "compile",
+        "debug": False,
+        "interrupt": True,
+        "include": ["something"],
+        "exclude": [],
+        "profile": None,
+        "full_load": False,
+        "start_dt": None,
+        "end_dt": None,
+    }
+
+
+def test_run_interrupt_debug():
+    output = get_output("compile -t something -i -d")
+
+    assert output == {
+        "command": "compile",
+        "debug": True,
+        "interrupt": True,
+        "include": ["something"],
+        "exclude": [],
+        "profile": None,
+        "full_load": False,
+        "start_dt": None,
+        "end_dt": None,
+    }
+
+
+def test_run_interrupt_multitasks():
+    output = get_output("run -t something -i -t somethingelse somesomeelse")
+
+    assert output == {
+        "command": "run",
+        "debug": False,
+        "interrupt": True,
         "include": ["something", "somethingelse", "somesomeelse"],
         "exclude": [],
         "profile": None,
@@ -255,6 +353,7 @@ def test_run_full():
     assert output == {
         "command": "run",
         "debug": False,
+        "interrupt": False,
         "include": ["something"],
         "exclude": [],
         "profile": None,
@@ -270,6 +369,7 @@ def test_compile_full():
     assert output == {
         "command": "compile",
         "debug": False,
+        "interrupt": False,
         "include": ["something"],
         "exclude": [],
         "profile": None,
@@ -285,6 +385,7 @@ def test_run_exclude():
     assert output == {
         "command": "run",
         "debug": False,
+        "interrupt": False,
         "include": [],
         "exclude": ["something"],
         "profile": None,
@@ -300,6 +401,7 @@ def test_compile_exclude():
     assert output == {
         "command": "compile",
         "debug": False,
+        "interrupt": False,
         "include": [],
         "exclude": ["something"],
         "profile": None,
@@ -315,6 +417,7 @@ def test_run_include_exclude():
     assert output == {
         "command": "run",
         "debug": False,
+        "interrupt": False,
         "include": ["somethingelse"],
         "exclude": ["something"],
         "profile": None,
@@ -330,6 +433,7 @@ def test_compile_include_exclude():
     assert output == {
         "command": "compile",
         "debug": False,
+        "interrupt": False,
         "include": ["somethingelse"],
         "exclude": ["something"],
         "profile": None,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,7 +18,7 @@ def cli():
 @tcli.click_run_options
 def run(
     debug,
-    interrupt,
+    fail_fast,
     tasks,
     exclude,
     upstream_prod,
@@ -39,13 +39,13 @@ def run(
     return {
         "command": "run",
         "debug": debug,
-        "interrupt": interrupt,
         "include": tasks,
         "exclude": exclude,
         "profile": profile,
         "full_load": full_load,
         "start_dt": start_dt,
         "end_dt": end_dt,
+        "fail_fast": fail_fast,
     }
 
 
@@ -53,7 +53,7 @@ def run(
 @tcli.click_run_options
 def compile(
     debug,
-    interrupt,
+    fail_fast,
     tasks,
     exclude,
     upstream_prod,
@@ -74,7 +74,7 @@ def compile(
     return {
         "command": "compile",
         "debug": debug,
-        "interrupt": interrupt,
+        "fail_fast": fail_fast,
         "include": tasks,
         "exclude": exclude,
         "profile": profile,
@@ -97,7 +97,7 @@ def test_simple_run():
     assert output == {
         "command": "run",
         "debug": False,
-        "interrupt": False,
+        "fail_fast": False,
         "include": [],
         "exclude": [],
         "profile": None,
@@ -113,7 +113,7 @@ def test_simple_compile():
     assert output == {
         "command": "compile",
         "debug": False,
-        "interrupt": False,
+        "fail_fast": False,
         "include": [],
         "exclude": [],
         "profile": None,
@@ -129,7 +129,7 @@ def test_run_one_task():
     assert output == {
         "command": "run",
         "debug": False,
-        "interrupt": False,
+        "fail_fast": False,
         "include": ["something"],
         "exclude": [],
         "profile": None,
@@ -145,7 +145,7 @@ def test_run_two_tasks_old():
     assert output == {
         "command": "run",
         "debug": False,
-        "interrupt": False,
+        "fail_fast": False,
         "include": ["something", "somethingelse"],
         "exclude": [],
         "profile": None,
@@ -161,7 +161,7 @@ def test_run_two_tasks_new():
     assert output == {
         "command": "run",
         "debug": False,
-        "interrupt": False,
+        "fail_fast": False,
         "include": ["something", "somethingelse"],
         "exclude": [],
         "profile": None,
@@ -177,7 +177,7 @@ def test_compile_one_task():
     assert output == {
         "command": "compile",
         "debug": False,
-        "interrupt": False,
+        "fail_fast": False,
         "include": ["something"],
         "exclude": [],
         "profile": None,
@@ -193,7 +193,7 @@ def test_compile_two_tasks_old():
     assert output == {
         "command": "compile",
         "debug": False,
-        "interrupt": False,
+        "fail_fast": False,
         "include": ["something", "somethingelse"],
         "exclude": [],
         "profile": None,
@@ -209,7 +209,7 @@ def test_compile_two_tasks_new():
     assert output == {
         "command": "compile",
         "debug": False,
-        "interrupt": False,
+        "fail_fast": False,
         "include": ["something", "somethingelse"],
         "exclude": [],
         "profile": None,
@@ -225,7 +225,7 @@ def test_run_debug():
     assert output == {
         "command": "run",
         "debug": True,
-        "interrupt": False,
+        "fail_fast": False,
         "include": ["something"],
         "exclude": [],
         "profile": None,
@@ -241,7 +241,7 @@ def test_compile_debug():
     assert output == {
         "command": "compile",
         "debug": True,
-        "interrupt": False,
+        "fail_fast": False,
         "include": ["something"],
         "exclude": [],
         "profile": None,
@@ -257,7 +257,7 @@ def test_run_debug_multitasks():
     assert output == {
         "command": "run",
         "debug": True,
-        "interrupt": False,
+        "fail_fast": False,
         "include": ["something", "somethingelse", "somesomeelse"],
         "exclude": [],
         "profile": None,
@@ -273,7 +273,7 @@ def test_compile_debug_multitasks():
     assert output == {
         "command": "compile",
         "debug": True,
-        "interrupt": False,
+        "fail_fast": False,
         "include": ["something", "somethingelse", "somesomeelse"],
         "exclude": [],
         "profile": None,
@@ -283,13 +283,13 @@ def test_compile_debug_multitasks():
     }
 
 
-def test_run_interrupt():
-    output = get_output("run -t something -i")
+def test_run_fail_fast():
+    output = get_output("run -t something --fail-fast")
 
     assert output == {
         "command": "run",
         "debug": False,
-        "interrupt": True,
+        "fail_fast": True,
         "include": ["something"],
         "exclude": [],
         "profile": None,
@@ -299,13 +299,13 @@ def test_run_interrupt():
     }
 
 
-def test_compile_interrupt():
-    output = get_output("compile -t something -i")
+def test_compile_fail_fast():
+    output = get_output("compile -t something --fail-fast")
 
     assert output == {
         "command": "compile",
         "debug": False,
-        "interrupt": True,
+        "fail_fast": True,
         "include": ["something"],
         "exclude": [],
         "profile": None,
@@ -315,13 +315,13 @@ def test_compile_interrupt():
     }
 
 
-def test_run_interrupt_debug():
-    output = get_output("compile -t something -i -d")
+def test_run_fail_fast_debug():
+    output = get_output("compile -t something --fail-fast -d")
 
     assert output == {
         "command": "compile",
         "debug": True,
-        "interrupt": True,
+        "fail_fast": True,
         "include": ["something"],
         "exclude": [],
         "profile": None,
@@ -331,13 +331,13 @@ def test_run_interrupt_debug():
     }
 
 
-def test_run_interrupt_multitasks():
-    output = get_output("run -t something -i -t somethingelse somesomeelse")
+def test_run_fail_fast_multitasks():
+    output = get_output("run -t something --fail-fast -t somethingelse somesomeelse")
 
     assert output == {
         "command": "run",
         "debug": False,
-        "interrupt": True,
+        "fail_fast": True,
         "include": ["something", "somethingelse", "somesomeelse"],
         "exclude": [],
         "profile": None,
@@ -353,7 +353,7 @@ def test_run_full():
     assert output == {
         "command": "run",
         "debug": False,
-        "interrupt": False,
+        "fail_fast": False,
         "include": ["something"],
         "exclude": [],
         "profile": None,
@@ -369,7 +369,7 @@ def test_compile_full():
     assert output == {
         "command": "compile",
         "debug": False,
-        "interrupt": False,
+        "fail_fast": False,
         "include": ["something"],
         "exclude": [],
         "profile": None,
@@ -385,7 +385,7 @@ def test_run_exclude():
     assert output == {
         "command": "run",
         "debug": False,
-        "interrupt": False,
+        "fail_fast": False,
         "include": [],
         "exclude": ["something"],
         "profile": None,
@@ -401,7 +401,7 @@ def test_compile_exclude():
     assert output == {
         "command": "compile",
         "debug": False,
-        "interrupt": False,
+        "fail_fast": False,
         "include": [],
         "exclude": ["something"],
         "profile": None,
@@ -417,7 +417,7 @@ def test_run_include_exclude():
     assert output == {
         "command": "run",
         "debug": False,
-        "interrupt": False,
+        "fail_fast": False,
         "include": ["somethingelse"],
         "exclude": ["something"],
         "profile": None,
@@ -433,7 +433,7 @@ def test_compile_include_exclude():
     assert output == {
         "command": "compile",
         "debug": False,
-        "interrupt": False,
+        "fail_fast": False,
         "include": ["somethingelse"],
         "exclude": ["something"],
         "profile": None,


### PR DESCRIPTION
Introduced `interrupt`/ `-i` flag. 
When the flag is set and a task fails, SAYN aborts the remaining of the execution.
