### PR TITLE
BugFix: DbObject Reference Level Complilation

### DIFF
--- a/sayn/database/__init__.py
+++ b/sayn/database/__init__.py
@@ -146,9 +146,9 @@ class Database:
     ) -> str:
         return (
             f"{database if database is not None else ''}"
-            f"{'.' if database is not None else ''}"
+            f"{'.' if database is not None and (schema is not None) else ''}"
             f"{schema if schema is not None else ''}"
-            f"{'.' if database is not None or (schema is not None) else ''}"
+            f"{'.' if schema is not None and (table is not None) else ''}"
             f"{table if table is not None else ''}"
         )
 

--- a/tests/test_db_object.py
+++ b/tests/test_db_object.py
@@ -236,6 +236,9 @@ def test_object_from_string_reference_level_database():
     compiled_object = compiler.from_string("db", level="db")
     assert base_object == compiled_object
 
+    compiled_object = compiler.from_string("db.", level="db")
+    assert base_object == compiled_object
+
     compiled_object = compiler.from_string("db..")
     assert base_object == compiled_object
 
@@ -253,3 +256,15 @@ def test_object_from_string_level_error():
 
     with pytest.raises(ValueError):
         compiler.from_string("test....")
+
+    with pytest.raises(ValueError):
+        compiler.from_string("test..", level="schema")
+
+    with pytest.raises(ValueError):
+        compiler.from_string("test.this..", level="schema")
+
+    with pytest.raises(ValueError):
+        compiler.from_string("test.this.that", level="schema")
+
+    with pytest.raises(ValueError):
+        compiler.from_string("test.this.that", level="db")


### PR DESCRIPTION
- Fixed `_obj_str` to not return trailing periods; 
- Ensured consistency between period and level formats for `dbObject` reference level